### PR TITLE
1.4.0-dev

### DIFF
--- a/jquery.sceditor.js
+++ b/jquery.sceditor.js
@@ -320,7 +320,7 @@
 				.bind("beforedeactivate keyup", saveRange)
 				.focus(function() {
 					lastRange = null;
-				})
+				});
 				
 			// auto-update original textbox on blur if option set to true
 			if(base.opts.autoUpdate){
@@ -3470,3 +3470,4 @@
 		});
 	};
 })(jQuery, window, document);
+


### PR DESCRIPTION
Added new option to auto-update original textbox on blur event occurring on SCEditor. Set by default to false, pass autoUpdate = true in options to enable.
