### PR TITLE
1.4.0-dev pull request

### DIFF
--- a/jquery.sceditor.js
+++ b/jquery.sceditor.js
@@ -206,6 +206,7 @@
 		/**
 		 * All the commands supported by the editor
 		 */
+	    options = options || {};
 		base.commands = $.extend({}, (options.commands || $.sceditor.commands));
 
 		/**
@@ -3473,6 +3474,10 @@
 
 			if($this.parents('.sceditor-container').length > 0)
 				return;
+			
+			if(options && options == "state"){
+				return  !$this.data('sceditor');
+			}  
 
 			if(!$this.data('sceditor'))
 				(new $.sceditor(this, options));


### PR DESCRIPTION
- fixed options "undefined" error due to none being supplied (now defaults to {} when no options passed to constructor, so that the extend can actually work)
- added support to check init state without actual initalization by passing string 'state' to $container.sceditor()
