### PR TITLE
Fix "sceditor-dropdown doesn't show off" with jquery < 1.7

### DIFF
--- a/jquery.sceditor.js
+++ b/jquery.sceditor.js
@@ -877,7 +877,7 @@
 		 */
 		base.closeDropDown = function (focus) {
 			if($dropdown) {
-				$dropdown.off().remove();
+				$dropdown.unbind().remove();
 				$dropdown = null;
 			}
 


### PR DESCRIPTION
.off() method has been added in jquery 1.7. 
To make SCEditor compatible with old jquery libraries we should use the .unbind() method instead.
http://api.jquery.com/off/
http://api.jquery.com/unbind/

(it's my first commit on github, sorry if I have just made a mistake)
