### PR TITLE
Fix for dom.removeWhiteSpace. 

### DIFF
--- a/src/jquery.sceditor.js
+++ b/src/jquery.sceditor.js
@@ -4416,10 +4416,18 @@
 						{
 							while(sibling.lastChild)
 								sibling = sibling.lastChild;
-
-							if(!isInline(sibling) || sibling.nodeType === 3)
+							
+							var	isSiblingInline = isInline(sibling);
+							
+							if(!isSiblingInline || sibling.nodeType === 3)
 							{
 								trimStart = sibling.nodeType === 3 ? /[\t\n\r ]$/.test(sibling.nodeValue) : true;
+								break;
+							}
+							else if (isSiblingInline && sibling.nodeType != 3)
+							{
+								// if the sibling is inline but it's not a text node, 
+								// we don't trim the start of this one
 								break;
 							}
 						}


### PR DESCRIPTION
If a text node is preceded by an inline element, the text node should not have its leading whitespace trimmed off.

Assume that the original HTML is like this,

"asdf " IMG " asdf"

When the existing code looks at the second text node, it checks its preceding sibling node. It's an IMG tag so it skips it, and checks the preceding 'asdf ' text node. It finds that it ends with whitespace, so it's safe to trim the whitespace from the second text node. Unfortunately that's incorrect, because there will no longer be whitespace between the IMG and the following 'asdf'.

This fix will accept the whitespace at the start of the current text node if its previous sibling is not a text node.

Actually, looking at the code I think just 'else' would be the same as the 'else if.'
