### PR TITLE
[issue/186] Add the shortcut information to the tooltip

### DIFF
--- a/src/jquery.sceditor.js
+++ b/src/jquery.sceditor.js
@@ -584,9 +584,10 @@
 					if(!base.commands[button] || $.inArray(button, exclude) > -1)
 						return;
 
+					var shortcutName = base.commands[button].shortcut ? " (" + base.commands[button].shortcut + ")" : "";
 					$button = _tmpl('toolbarButton', {
 							name: button,
-							dispName: base._(base.commands[button].tooltip || button)
+							dispName: base._(base.commands[button].tooltip || button) + shortcutName
 						}, true);
 
 					$button.data('sceditor-txtmode', !!base.commands[button].txtExec);
@@ -606,8 +607,11 @@
 					if(!base.commands[button].exec)
 						$button.addClass('disabled');
 
-					if(base.commands[button].shortcut)
+					if(base.commands[button].shortcut){
 						base.addShortcut(base.commands[button].shortcut, button);
+						// Add the shortcut info to the title
+						$button.attr('title', $button.attr('title') + shortcutName);
+					}
 
 					$group.append($button);
 				});


### PR DESCRIPTION
The information about what's the shortcut key for a command is completely hidden from the UI. This will make it so that that shortcut key shows in the tooltip when hovering a button and also in the button's text.
