### PR TITLE
RFC 2397 - The "data" URL scheme

### DIFF
--- a/src/jquery.sceditor.js
+++ b/src/jquery.sceditor.js
@@ -3446,7 +3446,7 @@
 	 */
 	$.sceditor.escapeUriScheme = function(url) {
 		var	path,
-			validSchemes = /^(?:https?|s?ftp|mailto|spotify|skype|ssh|teamspeak|tel):|(?:\/\/)/i,
+			validSchemes = /^(?:https?|s?ftp|mailto|spotify|skype|ssh|teamspeak|tel|data):|(?:\/\/)/i,
 			// If there is a : before a / then it has a scheme
 			hasScheme = /^[^\/]*:/i,
 			location = window.location;


### PR DESCRIPTION
RFC 2397 - The "data" URL scheme
http://tools.ietf.org/html/rfc2397
eg:
<img src="data:image/jpeg;base64,/9j/4AAQ.....">
