### PR TITLE
Closing balises

### DIFF
--- a/src/plugins/xhtml.js
+++ b/src/plugins/xhtml.js
@@ -399,14 +399,14 @@
 			var merge = {
 				bold: { txtExec: ['<strong>', '</strong>'] },
 				italic: { txtExec: ['<em>', '</em>'] },
-				underline: { txtExec: ['<span style="text-decoration: underline;">', '<span>'] },
-				strike: { txtExec: ['<span style="text-decoration: line-through;">', '<span>'] },
+				underline: { txtExec: ['<span style="text-decoration: underline;">', '</span>'] },
+				strike: { txtExec: ['<span style="text-decoration: line-through;">', '</span>'] },
 				subscript: { txtExec: ['<sub>', '</sub>'] },
 				superscript: { txtExec: ['<sup>', '</sup>'] },
-				left: { txtExec: ['<div style="text-align: left;">', '<div>'] },
-				center: { txtExec: ['<div style="text-align: center;">', '<div>'] },
-				right: { txtExec: ['<div style="text-align: right;">', '<div>'] },
-				justify: { txtExec: ['<div style="text-align: justify;">', '<div>'] },
+				left: { txtExec: ['<div style="text-align: left;">', '</div>'] },
+				center: { txtExec: ['<div style="text-align: center;">', '</div>'] },
+				right: { txtExec: ['<div style="text-align: right;">', '</div>'] },
+				justify: { txtExec: ['<div style="text-align: justify;">', '</div>'] },
 				font: { txtExec: function(caller) {
 					var editor = this;
 


### PR DESCRIPTION
bug correction: it was "<span>" and "<div>" instead of "</span>" and "</div>" to close underline / strike / left / center / right / justify