### PR TITLE
Added signal/event to handle pasted data

### DIFF
--- a/src/jquery.sceditor.js
+++ b/src/jquery.sceditor.js
@@ -1408,7 +1408,7 @@
 		handlePasteData = function(elm, pastearea) {
 			// fix any invalid nesting
 			$.sceditor.dom.fixNesting(pastearea);
-// TODO: Trigger custom paste event to allow filtering (pre and post converstion?)
+
 			var pasteddata = pastearea.innerHTML;
 
 			if (pluginManager.hasHandler('toSource'))
@@ -1418,6 +1418,12 @@
 
 			if (pluginManager.hasHandler('toWysiwyg'))
 				pasteddata = pluginManager.callOnlyFirst('toWysiwyg', pasteddata, true);
+
+			if (pluginManager.hasHandler('pasteData')) {
+				pasteddata = pluginManager.callOnlyFirst(
+					'pasteData', pasteddata
+				);
+			}
 
 			rangeHelper.restoreRange();
 			base.wysiwygEditorInsertHtml(pasteddata, null, true);

--- a/src/plugins/disableImageStream.js
+++ b/src/plugins/disableImageStream.js
@@ -22,14 +22,14 @@
 		 * @private
 		 */
 		base.init = function () {
-      document.title = 'DisableImageStream Loaded';
+			document.title = 'DisableImageStream Loaded';
 		};
 
-    base.signalPasteData = function(pastedata) {
-      if (/data:image/ig.test(pastedata)) {
-        return '';
-      }
-      return pastedata;
-    }
+		base.signalPasteData = function(pastedata) {
+		  if (/data:image/ig.test(pastedata)) {
+			return '';
+		  }
+		  return pastedata;
+		};
 	};
 })(jQuery);

--- a/src/plugins/disableImageStream.js
+++ b/src/plugins/disableImageStream.js
@@ -1,0 +1,35 @@
+/**
+ * SCEditor Image stream filtering plugin
+ * http://www.sceditor.com/
+ *
+ * Copyright (C) 2015, Francis Schiavo (francisschiavo.com)
+ *
+ * SCEditor is licensed under the MIT license:
+ *	http://www.opensource.org/licenses/mit-license.php
+ *
+ * @fileoverview SCEditor Image stream filtering plugin
+ * @author Francis Schiavo
+ * @requires jQuery
+ */
+(function ($) {
+	'use strict';
+
+	$.sceditor.plugins.disableImageStream = function () {
+		var base = this;
+
+		/**
+		 * Private functions
+		 * @private
+		 */
+		base.init = function () {
+      document.title = 'DisableImageStream Loaded';
+		};
+
+    base.signalPasteData = function(pastedata) {
+      if (/data:image/ig.test(pastedata)) {
+        return '';
+      }
+      return pastedata;
+    }
+	};
+})(jQuery);

--- a/src/plugins/disableImageStream.js
+++ b/src/plugins/disableImageStream.js
@@ -22,14 +22,14 @@
 		 * @private
 		 */
 		base.init = function () {
-			document.title = 'DisableImageStream Loaded';
+      document.title = 'DisableImageStream Loaded';
 		};
 
-		base.signalPasteData = function(pastedata) {
-		  if (/data:image/ig.test(pastedata)) {
-			return '';
-		  }
-		  return pastedata;
-		};
+    base.signalPasteData = function(pastedata) {
+      if (/data:image/ig.test(pastedata)) {
+        return '';
+      }
+      return pastedata;
+    }
 	};
 })(jQuery);


### PR DESCRIPTION
I added a new event (signalPasteData) to allow custom plugins to handle pasted data.
The event is fired only if enablePasteFiltering is set to true.

There is also an optional plugin to disable image streams in img src attributes.

My motivation for those changes are to provide a way to handle pasted data and filter some contents, e.g. disable base64 embedded images on bbcode.