### PR TITLE
Improved Grunt tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 sceditor.sublime-project
 sceditor.sublime-workspace
-node_modules/*
-distributable/*
-dist/*
-minified/*
-docs/*
+/node_modules
+/distributable
+/dist
+/minified
+/docs

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,135 +1,33 @@
+// Source: https://github.com/angular/angular.js/blob/master/.jscs.json
 {
-	"requireCurlyBraces": [
-		"if", "else", "for", "while", "do", "try", "catch"
-	],
-	"requireSpaceAfterKeywords": [
-		"if", "else", "for", "while", "do", "switch", "return", "try", "catch"
-	],
-	"requireSpaceBeforeBlockStatements": true,
-	"requireParenthesesAroundIIFE": true,
-	"requireSpacesInFunctionExpression": {
-		"beforeOpeningRoundBrace": true,
-		"beforeOpeningCurlyBrace": true
-	},
-	"requireSpacesInAnonymousFunctionExpression": {
-		"beforeOpeningRoundBrace": true,
-		"beforeOpeningCurlyBrace": true
-	},
-	"disallowSpacesInNamedFunctionExpression": {
-		"beforeOpeningRoundBrace": true
-	},
-	"disallowSpacesInFunctionDeclaration": {
-		"beforeOpeningRoundBrace": true
-	},
-
-	//"disallowMultipleVarDecl": true,
-
-	"requireBlocksOnNewline": true,
-
-	//"disallowPaddingNewlinesInBlock": true,
-
-	"disallowEmptyBlocks": true,
-
-	//"disallowQuotedKeysInObjects": "allButReserved", no for langs
-
-	"disallowSpaceAfterObjectKeys": true,
-	"requireCommaBeforeLineBreak": true,
-	"requireOperatorBeforeLineBreak": [
-		"?",
-		"+",
-		"-",
-		"/",
-		"*",
-		"=",
-		"==",
-		"===",
-		"!=",
-		"!==",
-		">",
-		">=",
-		"<",
-		"<="
-	],
-	"disallowLeftStickedOperators": [
-		"?",
-		"+",
-		"-",
-		"/",
-		"*",
-		"=",
-		"==",
-		"===",
-		"!=",
-		"!==",
-		">",
-		">=",
-		"<",
-		"<="
-	],
-	"disallowRightStickedOperators": [
-		"?",
-		"+",
-		"/",
-		"*",
-		":",
-		"=",
-		"==",
-		"===",
-		"!=",
-		"!==",
-		">",
-		">=",
-		"<",
-		"<="
-	],
-	"requireRightStickedOperators": [
-		"!"
-	],
-	"requireLeftStickedOperators": [
-		","
-	],
-	"disallowSpaceAfterPrefixUnaryOperators": [
-		"++", "--", "+", "-", "~", "!"
-	],
-	"disallowSpaceBeforePostfixUnaryOperators": [
-		"++", "--"
-	],
-	"requireSpaceBeforeBinaryOperators": [
-		"+", "-", "/", "*", "=", "==", "===", "!=", "!=="
-	],
-	"requireSpaceAfterBinaryOperators": [
-		"+", "-", "/", "*", "=", "==", "===", "!=", "!=="
-	],
-	"requireCamelCaseOrUpperCaseIdentifiers": true,
-	"disallowKeywords": ["with"],
-	"disallowMultipleLineStrings": true,
-	"validateLineBreaks": "LF",
-	"validateQuoteMarks": "'",
-	"validateIndentation": "\t",
-	"disallowMixedSpacesAndTabs": "smart",
-	"disallowTrailingWhitespace": true,
-
-	//"disallowTrailingComma": true,
-
-	"disallowKeywordsOnNewLine": ["else"],
-	"requireLineFeedAtFileEnd": true,
-	"maximumLineLength": 80,
-	"requireCapitalizedConstructors": true,
-	"safeContextKeyword": ["base", "that", "editor"],
-
-	//"requireDotNotation": true, not for langs
-
-	"validateJSDoc": {
-		"checkParamNames": true,
-
-		// Can't check this as optional params like ...args currently cause an
-		// error, see: https://github.com/mdevils/node-jscs/issues/59
-		//"checkRedundantParams": true,
-
-		"requireParamTypes": true
-	},
-	"excludeFiles": [
-		"node_modules/**",
-		"**.min.js"
-	]
+"excludeFiles": ["node_modules/**", "**.min.js"],
+"disallowKeywords": ["with"],
+"disallowKeywordsOnNewLine": ["else"],
+//"disallowMixedSpacesAndTabs": true,
+"disallowMultipleLineStrings": true,
+//"disallowNewlineBeforeBlockStatements": true,
+"disallowSpaceAfterObjectKeys": true,
+"disallowSpaceAfterPrefixUnaryOperators": ["++", "--", "+", "-", "~", "!"],
+"disallowSpaceBeforeBinaryOperators": [","],
+"disallowSpaceBeforePostfixUnaryOperators": ["++", "--"],
+"disallowSpacesInsideArrayBrackets": true,
+//"disallowSpacesInsideParentheses": true,
+"disallowTrailingComma": true,
+"disallowTrailingWhitespace": true,
+"requireCommaBeforeLineBreak": true,
+"requireLineFeedAtFileEnd": true,
+"requireSpaceAfterBinaryOperators": ["?", ":", "+", "-", "/", "*", "%", "==", "===", "!=", "!==", ">", ">=", "<", "<=", "&&", "||"],
+"requireSpaceBeforeBinaryOperators": ["?", ":", "+", "-", "/", "*", "%", "==", "===", "!=", "!==", ">", ">=", "<", "<=", "&&", "||"],
+"requireSpaceAfterKeywords": ["if", "else", "for", "while", "do", "switch", "return", "try", "catch"],
+//"requireSpaceBeforeBlockStatements": true,
+  "requireSpacesInConditionalExpression": {
+    "afterTest": true,
+    "beforeConsequent": true,
+    "afterConsequent": true,
+    "beforeAlternate": true
+  },
+"requireSpacesInFunction": {
+"beforeOpeningCurlyBrace": true
+},
+"validateLineBreaks": "LF"
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -455,13 +455,20 @@ module.exports = function (grunt) {
 
 		// Compress the WYSIWYG CSS
 		cssmin: {
-			build: {
-				files: {
-					'minified/jquery.sceditor.default.min.css': [
-						'src/jquery.sceditor.default.css'
-					]
-				}
-			}
+            build: {
+                files: [
+                    {
+                        'minified/jquery.sceditor.default.min.css': ['src/jquery.sceditor.default.css']
+                    },
+                    {
+                        expand: true,
+                        cwd: 'minified/themes',
+                        src: ['*.min.css'],
+                        dest: 'minified/themes',
+                        ext: '.min.css'
+                    }
+                ]
+            }
 		},
 
 		// Creates the distributable ZIP file

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -440,6 +440,19 @@ module.exports = function (grunt) {
 			}
 		},
 
+        // Manage CSS vendor prefixes
+        autoprefixer: {
+            build: {
+                options: {
+                    browsers: ['last 4 versions', 'ie 6', 'ie 7', 'ie 8', 'ie 9']
+                },
+                expand: true,
+                flatten: true,
+                src: 'minified/themes/*.css',
+                dest: 'minified/themes/'
+            }
+        },
+
 		// Compress the WYSIWYG CSS
 		cssmin: {
 			build: {
@@ -469,7 +482,8 @@ module.exports = function (grunt) {
 	});
 
 
-	grunt.loadNpmTasks('grunt-contrib-clean');
+    grunt.loadNpmTasks('grunt-autoprefixer');
+    grunt.loadNpmTasks('grunt-contrib-clean');
 	grunt.loadNpmTasks('grunt-contrib-compress');
 	grunt.loadNpmTasks('grunt-contrib-concat');
 	grunt.loadNpmTasks('grunt-contrib-connect');
@@ -502,6 +516,7 @@ module.exports = function (grunt) {
 		'webpack:build',
 		'uglify:build',
 		'less:build',
+        'autoprefixer:build',
 		'cssmin:build'
 	]);
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -478,7 +478,7 @@ module.exports = function (grunt) {
 	grunt.loadNpmTasks('grunt-contrib-less');
 	grunt.loadNpmTasks('grunt-contrib-qunit');
 	grunt.loadNpmTasks('grunt-contrib-uglify');
-	grunt.loadNpmTasks('grunt-jscs-checker');
+	grunt.loadNpmTasks('grunt-jscs');
 	grunt.loadNpmTasks('grunt-saucelabs');
 	grunt.loadNpmTasks('grunt-webpack');
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,6 @@
 /*global module:false, process:false*/
 module.exports = function (grunt) {
+    require('time-grunt')(grunt);
 	'use strict';
 
 	var sauceConfig = process.env.HOME + '/.sauce.json';

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -234,7 +234,7 @@ module.exports = function (grunt) {
 				src: 'languages/**/*.js',
 				options: {
 					config: '.jscsrc',
-					maximumLineLength: 400,
+					maximumLineLength: 400
 				}
 			}
 		},
@@ -460,8 +460,7 @@ module.exports = function (grunt) {
 					{
 						expand: true,
 						cwd: 'dist/',
-						src: ['**'],
-						dest: '/'
+						src: ['**']
 					}
 				]
 			}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "grunt-contrib-less": "^1.0.0",
     "grunt-contrib-qunit": "~0.5.2",
     "grunt-contrib-uglify": "^0.7.0",
-    "grunt-jscs-checker": "^0.4.3",
+    "grunt-jscs": "^1.5.0",
     "grunt-saucelabs": "^8.5.0",
     "grunt-webpack": "^1.0.8"
   }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "grunt-contrib-uglify": "^0.7.0",
     "grunt-jscs": "^1.5.0",
     "grunt-saucelabs": "^8.5.0",
-    "grunt-webpack": "^1.0.8"
+    "grunt-webpack": "^1.0.8",
+    "time-grunt": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "grunt": "~0.4.5",
+    "grunt-autoprefixer": "^2.2.0",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-compress": "^0.13.0",
     "grunt-contrib-concat": "~0.5.0",

--- a/package.json
+++ b/package.json
@@ -13,19 +13,18 @@
   },
   "devDependencies": {
     "grunt": "~0.4.5",
-    "grunt-cli": "~0.1.13",
-    "grunt-contrib-clean": "~0.5.0",
-    "grunt-contrib-compress": "~0.9.1",
-    "grunt-contrib-concat": "~0.4.0",
-    "grunt-contrib-connect": "^0.7.1",
-    "grunt-contrib-copy": "~0.5.0",
-    "grunt-contrib-cssmin": "~0.9.0",
-    "grunt-contrib-jshint": "~0.10.0",
-    "grunt-contrib-less": "~0.11.0",
-    "grunt-contrib-qunit": "~0.4.0",
-    "grunt-contrib-uglify": "~0.4.0",
+    "grunt-contrib-clean": "^0.6.0",
+    "grunt-contrib-compress": "^0.13.0",
+    "grunt-contrib-concat": "~0.5.0",
+    "grunt-contrib-connect": "^0.9.0",
+    "grunt-contrib-copy": "^0.7.0",
+    "grunt-contrib-cssmin": "^0.11.0",
+    "grunt-contrib-jshint": "~0.11.0",
+    "grunt-contrib-less": "^1.0.0",
+    "grunt-contrib-qunit": "~0.5.2",
+    "grunt-contrib-uglify": "^0.7.0",
     "grunt-jscs-checker": "^0.4.3",
-    "grunt-saucelabs": "^8.0.2",
-    "grunt-webpack": "^1.0.5"
+    "grunt-saucelabs": "^8.5.0",
+    "grunt-webpack": "^1.0.8"
   }
 }

--- a/src/themes/inc/defaultbase.less
+++ b/src/themes/inc/defaultbase.less
@@ -310,9 +310,6 @@ div.sceditor-dropdown div
 		line-height: 0;
 		text-align: left;
 
-		-webkit-user-select: none;
-		-moz-user-select: none;
-		-ms-user-select: none;
 		user-select: none;
 
 		.rounded(3px 3px 0 0);

--- a/src/themes/inc/elements.less
+++ b/src/themes/inc/elements.less
@@ -42,27 +42,13 @@
   border-bottom: solid 1px @bottom-color;
 }
 .drop-shadow(@x-axis: 0, @y-axis: 1px, @blur: 2px, @alpha: 0.1) {
-  -webkit-box-shadow: @x-axis @y-axis @blur rgba(0, 0, 0, @alpha);
-  -moz-box-shadow: @x-axis @y-axis @blur rgba(0, 0, 0, @alpha);
   box-shadow: @x-axis @y-axis @blur rgba(0, 0, 0, @alpha);
 }
 .rounded(@radius: 2px) {
-  -webkit-border-radius: @radius;
-  -moz-border-radius: @radius;
   border-radius: @radius;
-  -moz-background-clip: padding;
-  -webkit-background-clip: padding-box;
   background-clip: padding-box;
 }
 .border-radius(@topright: 0, @bottomright: 0, @bottomleft: 0, @topleft: 0) {
-  -webkit-border-top-right-radius: @topright;
-  -webkit-border-bottom-right-radius: @bottomright;
-  -webkit-border-bottom-left-radius: @bottomleft;
-  -webkit-border-top-left-radius: @topleft;
-  -moz-border-radius-topright: @topright;
-  -moz-border-radius-bottomright: @bottomright;
-  -moz-border-radius-bottomleft: @bottomleft;
-  -moz-border-radius-topleft: @topleft;
   border-top-right-radius: @topright;
   border-bottom-right-radius: @bottomright;
   border-bottom-left-radius: @bottomleft;
@@ -70,70 +56,36 @@
   -moz-background-clip: padding; -webkit-background-clip: padding-box; background-clip: padding-box;
 }
 .opacity(@opacity: 0.5) {
-  -moz-opacity: @opacity;
-  -khtml-opacity: @opacity;
-  -webkit-opacity: @opacity;
   opacity: @opacity;
   @opperc: @opacity * 100;
   -ms-filter: ~"progid:DXImageTransform.Microsoft.Alpha(opacity=@{opperc})";
   filter: ~"alpha(opacity=@{opperc})";
 }
 .transition-duration(@duration: 0.2s) {
-  -moz-transition-duration: @duration;
-  -webkit-transition-duration: @duration;
   transition-duration: @duration;
 }
 .rotation(@deg:5deg){
-  -webkit-transform: rotate(@deg);
-  -moz-transform: rotate(@deg);
-  -ms-transform: rotate(@deg);
   transform: rotate(@deg);
 }
 .scale(@ratio:1.5){
-  -webkit-transform:scale(@ratio);
-  -moz-transform:scale(@ratio);
   transform:scale(@ratio);
 }
 .transition(@duration:0.2s, @ease:ease-out) {
-  -webkit-transition: all @duration @ease;
-  -moz-transition: all @duration @ease;
   transition: all @duration @ease;
 }
 .inner-shadow(@horizontal:0, @vertical:1px, @blur:2px, @alpha: 0.4) {
-  -webkit-box-shadow: inset @horizontal @vertical @blur rgba(0, 0, 0, @alpha);
-  -moz-box-shadow: inset @horizontal @vertical @blur rgba(0, 0, 0, @alpha);
   box-shadow: inset @horizontal @vertical @blur rgba(0, 0, 0, @alpha);
 }
 .box-shadow(@arguments) {
-  -webkit-box-shadow: @arguments;
-  -moz-box-shadow: @arguments;
   box-shadow: @arguments;
 }
 .box-sizing(@sizing: border-box) {
-  -ms-box-sizing: @sizing;
-  -moz-box-sizing: @sizing;
-  -webkit-box-sizing: @sizing;
   box-sizing: @sizing;
 }
 .user-select(@argument: none) {
-  -webkit-user-select: @argument;
-  -moz-user-select: @argument;
-  -ms-user-select: @argument;
   user-select: @argument;
 }
 .columns(@colwidth: 250px, @colcount: 0, @colgap: 50px, @columnRuleColor: #EEE, @columnRuleStyle: solid, @columnRuleWidth: 1px) {
-  -moz-column-width: @colwidth;
-  -moz-column-count: @colcount;
-  -moz-column-gap: @colgap;
-  -moz-column-rule-color: @columnRuleColor;
-  -moz-column-rule-style: @columnRuleStyle;
-  -moz-column-rule-width: @columnRuleWidth;
-  -webkit-column-width: @colwidth;
-  -webkit-column-count: @colcount;
-  -webkit-column-gap: @colgap;
-  -webkit-column-rule-color: @columnRuleColor;
-  -webkit-column-rule-style: @columnRuleStyle;
-  -webkit-column-rule-width: @columnRuleWidth;
   column-width: @colwidth;
   column-count: @colcount;
   column-gap: @colgap;
@@ -142,9 +94,5 @@
   column-rule-width: @columnRuleWidth;
 }
 .translate(@x:0, @y:0) {
-  -moz-transform: translate(@x, @y);
-  -webkit-transform: translate(@x, @y);
-  -o-transform: translate(@x, @y);
-  -ms-transform: translate(@x, @y);
   transform: translate(@x, @y);
 }

--- a/src/themes/modern.less
+++ b/src/themes/modern.less
@@ -24,11 +24,6 @@
 
 div.sceditor-toolbar {
 	background: #ccc;
-	background: -moz-linear-gradient(top, #cccccc 0%, #b2b2b2 100%);
-	background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#cccccc), color-stop(100%,#b2b2b2));
-	background: -webkit-linear-gradient(top, #cccccc 0%,#b2b2b2 100%);
-	background: -o-linear-gradient(top, #cccccc 0%,#b2b2b2 100%);
-	background: -ms-linear-gradient(top, #cccccc 0%,#b2b2b2 100%);
 	background: linear-gradient(to bottom, #cccccc 0%,#b2b2b2 100%);
 	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#cccccc', endColorstr='#b2b2b2',GradientType=0 );
 }

--- a/src/themes/office-toolbar.less
+++ b/src/themes/office-toolbar.less
@@ -20,13 +20,7 @@
 
 div.sceditor-toolbar {
 	border-bottom: 1px solid #95a9c3;
-
 	background: #dee8f5;
-	background: -moz-linear-gradient(top, #dee8f5 0%, #c7d8ed 29%, #ccdcee 61%, #c0d8ef 100%);
-	background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#dee8f5), color-stop(29%,#c7d8ed), color-stop(61%,#ccdcee), color-stop(100%,#c0d8ef));
-	background: -webkit-linear-gradient(top, #dee8f5 0%,#c7d8ed 29%,#ccdcee 61%,#c0d8ef 100%);
-	background: -o-linear-gradient(top, #dee8f5 0%,#c7d8ed 29%,#ccdcee 61%,#c0d8ef 100%);
-	background: -ms-linear-gradient(top, #dee8f5 0%,#c7d8ed 29%,#ccdcee 61%,#c0d8ef 100%);
 	background: linear-gradient(to bottom, #dee8f5 0%,#c7d8ed 29%,#ccdcee 61%,#c0d8ef 100%);
 	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#dee8f5', endColorstr='#c0d8ef',GradientType=0 );
 }
@@ -39,13 +33,7 @@ div.sceditor-toolbar {
 		border: 1px solid #7596bf;
 		background: transparent;
 		padding: 0;
-
 		background: #cadcf0;
-		background: -moz-linear-gradient(top, #cadcf0 24%, #bcd0e9 38%, #d0e1f7 99%);
-		background: -webkit-gradient(linear, left top, left bottom, color-stop(24%,#cadcf0), color-stop(38%,#bcd0e9), color-stop(99%,#d0e1f7));
-		background: -webkit-linear-gradient(top, #cadcf0 24%,#bcd0e9 38%,#d0e1f7 99%);
-		background: -o-linear-gradient(top, #cadcf0 24%,#bcd0e9 38%,#d0e1f7 99%);
-		background: -ms-linear-gradient(top, #cadcf0 24%,#bcd0e9 38%,#d0e1f7 99%);
 		background: linear-gradient(to bottom, #cadcf0 24%,#bcd0e9 38%,#d0e1f7 99%);
 		filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#cadcf0', endColorstr='#d0e1f7',GradientType=0 );
 	}
@@ -57,16 +45,7 @@ div.sceditor-toolbar {
 			height: 16px;
 			padding: 3px 4px;
 			.rounded(0);
-
-			-webkit-box-shadow:	inset 0 1px #d5e3f1,
-						inset 0 -1px #e3edfb,
-						inset 1px 0 #cddcef,
-						inset -1px 0 #b8ceea;
-			-moz-box-shadow:	inset 0 1px #d5e3f1,
-						inset 0 -1px #e3edfb,
-						inset 1px 0 #cddcef,
-						inset -1px 0 #b8ceea;
-			box-shadow:		inset 0 1px #d5e3f1,
+			box-shadow:	inset 0 1px #d5e3f1,
 						inset 0 -1px #e3edfb,
 						inset 1px 0 #cddcef,
 						inset -1px 0 #b8ceea;
@@ -81,21 +60,9 @@ div.sceditor-toolbar {
 		}
 		.sceditor-button.active {
 			background: rgb(251,219,181);
-			background: -moz-linear-gradient(top, rgba(251,219,181,1) 11%, rgba(254,180,86,1) 29%, rgba(253,235,159,1) 99%);
-			background: -webkit-gradient(linear, left top, left bottom, color-stop(11%,rgba(251,219,181,1)), color-stop(29%,rgba(254,180,86,1)), color-stop(99%,rgba(253,235,159,1)));
-			background: -webkit-linear-gradient(top, rgba(251,219,181,1) 11%,rgba(254,180,86,1) 29%,rgba(253,235,159,1) 99%);
-			background: -o-linear-gradient(top, rgba(251,219,181,1) 11%,rgba(254,180,86,1) 29%,rgba(253,235,159,1) 99%);
-			background: -ms-linear-gradient(top, rgba(251,219,181,1) 11%,rgba(254,180,86,1) 29%,rgba(253,235,159,1) 99%);
 			background: linear-gradient(top, rgba(251,219,181,1) 11%,rgba(254,180,86,1) 29%,rgba(253,235,159,1) 99%);
 			filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#fbdbb5', endColorstr='#fdeb9f',GradientType=0 );
-
-			-webkit-box-shadow:	inset 0 1px #ebd1b4,
-						inset 0 -1px #ffe47f,
-						inset -1px 0 #b8ceea;
-			-moz-box-shadow:	inset 0 1px #ebd1b4,
-						inset 0 -1px #ffe47f,
-						inset -1px 0 #b8ceea;
-			box-shadow:		inset 0 1px #ebd1b4,
+			box-shadow:	inset 0 1px #ebd1b4,
 						inset 0 -1px #ffe47f,
 						inset -1px 0 #b8ceea;
 		}
@@ -104,21 +71,9 @@ div.sceditor-toolbar {
 		}
 		.sceditor-button:hover {
 			background: #fef7d5;
-			background: -moz-linear-gradient(top,  #fef7d5 0%, #fae5a9 42%, #ffd048 42%, #ffe59f 100%);
-			background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#fef7d5), color-stop(42%,#fae5a9), color-stop(42%,#ffd048), color-stop(100%,#ffe59f));
-			background: -webkit-linear-gradient(top,  #fef7d5 0%,#fae5a9 42%,#ffd048 42%,#ffe59f 100%);
-			background: -o-linear-gradient(top,  #fef7d5 0%,#fae5a9 42%,#ffd048 42%,#ffe59f 100%);
-			background: -ms-linear-gradient(top,  #fef7d5 0%,#fae5a9 42%,#ffd048 42%,#ffe59f 100%);
 			background: linear-gradient(to bottom,  #fef7d5 0%,#fae5a9 42%,#ffd048 42%,#ffe59f 100%);
 			filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#fef7d5', endColorstr='#ffe59f',GradientType=0 );
-
-			-webkit-box-shadow:	inset 0 1px #fffbe8,
-						inset -1px 0 #ffefc4,
-						inset 0 -1px #fff9cc;
-			-moz-box-shadow:	inset 0 1px #fffbe8,
-						inset -1px 0 #ffefc4,
-						inset 0 -1px #fff9cc;
-			box-shadow:		inset 0 1px #fffbe8,
+			box-shadow:	inset 0 1px #fffbe8,
 						inset -1px 0 #ffefc4,
 						inset 0 -1px #fff9cc;
 		}
@@ -127,19 +82,9 @@ div.sceditor-toolbar {
 		}
 		.sceditor-button:active {
 			background: #e7a66d;
-			background: -moz-linear-gradient(top, #e7a66d 0%, #fcb16d 1%, #ff8d05 42%, #ffc450 100%);
-			background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#e7a66d), color-stop(1%,#fcb16d), color-stop(42%,#ff8d05), color-stop(100%,#ffc450));
-			background: -webkit-linear-gradient(top, #e7a66d 0%,#fcb16d 1%,#ff8d05 42%,#ffc450 100%);
-			background: -o-linear-gradient(top, #e7a66d 0%,#fcb16d 1%,#ff8d05 42%,#ffc450 100%);
-			background: -ms-linear-gradient(top, #e7a66d 0%,#fcb16d 1%,#ff8d05 42%,#ffc450 100%);
 			background: linear-gradient(to bottom, #e7a66d 0%,#fcb16d 1%,#ff8d05 42%,#ffc450 100%);
 			filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#e7a66d', endColorstr='#ffc450',GradientType=0 );
-
-			-webkit-box-shadow:	inset 0 1px 1px #7b6645,
-						inset 0 -1px #d19c33;
-			-moz-box-shadow:	inset 0 1px 1px #7b6645,
-						inset 0 -1px #d19c33;
-			box-shadow:		inset 0 1px 1px #7b6645,
+			box-shadow:	inset 0 1px 1px #7b6645,
 						inset 0 -1px #d19c33;
 		}
 		.ie9 .sceditor-button:active {
@@ -147,19 +92,9 @@ div.sceditor-toolbar {
 		}
 		.sceditor-button.active:hover {
 			background: #dba368;
-			background: -moz-linear-gradient(top, #dba368 0%, #ffbd79 4%, #fea335 34%, #ffc64c 66%, #fee069 100%);
-			background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#dba368), color-stop(4%,#ffbd79), color-stop(34%,#fea335), color-stop(66%,#ffc64c), color-stop(100%,#fee069));
-			background: -webkit-linear-gradient(top, #dba368 0%,#ffbd79 4%,#fea335 34%,#ffc64c 66%,#fee069 100%);
-			background: -o-linear-gradient(top, #dba368 0%,#ffbd79 4%,#fea335 34%,#ffc64c 66%,#fee069 100%);
-			background: -ms-linear-gradient(top, #dba368 0%,#ffbd79 4%,#fea335 34%,#ffc64c 66%,#fee069 100%);
 			background: linear-gradient(to bottom, #dba368 0%,#ffbd79 4%,#fea335 34%,#ffc64c 66%,#fee069 100%);
 			filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#dba368', endColorstr='#fee069',GradientType=0 );
-
-			-webkit-box-shadow:	inset 0 1px 1px #9e8255,
-						inset 0 -1px #fcce6b;
-			-moz-box-shadow:	inset 0 1px 1px #9e8255,
-						inset 0 -1px #fcce6b;
-			box-shadow:		inset 0 1px 1px #9e8255,
+			box-shadow:	inset 0 1px 1px #9e8255,
 						inset 0 -1px #fcce6b;
 		}
 		.ie9 .sceditor-button.active:hover {

--- a/src/themes/office.less
+++ b/src/themes/office.less
@@ -12,11 +12,6 @@
 
 .sceditor-container {
 	background: rgb(163,194,234);
-	background: -moz-linear-gradient(top, rgba(163,194,234,1) 0%, rgba(109,146,193,1) 39%, rgba(87,127,179,1) 64%, rgba(101,145,204,1) 100%);
-	background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(163,194,234,1)), color-stop(39%,rgba(109,146,193,1)), color-stop(64%,rgba(87,127,179,1)), color-stop(100%,rgba(101,145,204,1)));
-	background: -webkit-linear-gradient(top, rgba(163,194,234,1) 0%,rgba(109,146,193,1) 39%,rgba(87,127,179,1) 64%,rgba(101,145,204,1) 100%);
-	background: -o-linear-gradient(top, rgba(163,194,234,1) 0%,rgba(109,146,193,1) 39%,rgba(87,127,179,1) 64%,rgba(101,145,204,1) 100%);
-	background: -ms-linear-gradient(top, rgba(163,194,234,1) 0%,rgba(109,146,193,1) 39%,rgba(87,127,179,1) 64%,rgba(101,145,204,1) 100%);
 	background: linear-gradient(top, rgba(163,194,234,1) 0%,rgba(109,146,193,1) 39%,rgba(87,127,179,1) 64%,rgba(101,145,204,1) 100%);
 	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#a3c2ea', endColorstr='#6591cc',GradientType=0 );
 }
@@ -28,8 +23,5 @@
 	background: #fff;
 	margin: 7px 40px;
 	padding: 20px;
-
-	-webkit-box-shadow:	1px 1px 5px #293a52;
-	-moz-box-shadow:	1px 1px 5px #293a52;
 	box-shadow:		1px 1px 5px #293a52;
 }

--- a/src/themes/square.less
+++ b/src/themes/square.less
@@ -30,11 +30,6 @@
 
 	div.sceditor-toolbar, div.sceditor-group {
 		background: #f2f2f2;
-		background: -moz-linear-gradient(top, #f2f2f2 0%, #dddddd 89%);
-		background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#f2f2f2), color-stop(89%,#dddddd));
-		background: -webkit-linear-gradient(top, #f2f2f2 0%,#dddddd 89%);
-		background: -o-linear-gradient(top, #f2f2f2 0%,#dddddd 89%);
-		background: -ms-linear-gradient(top, #f2f2f2 0%,#dddddd 89%);
 		background: linear-gradient(to bottom, #f2f2f2 0%,#dddddd 89%);
 		filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f2f2f2', endColorstr='#dddddd',GradientType=0 );
 	}
@@ -42,10 +37,6 @@
 	div.sceditor-toolbar {
 		padding: 0;
 		border-bottom: 1px solid #bbb;
-
-		-moz-background-size: 100% 32px;
-		-o-background-size: 100% 32px;
-		-webkit-background-size: 100% 32px;
 		background-size: 100% 32px;
 	}
 		div.sceditor-group {


### PR DESCRIPTION
## Improved Grunt tasks  

* NPM modules updated to the newest versions  
* **grunt-jscs-checker** replaced to **grunt-jscs**  
Reason: npm WARN deprecated grunt-jscs-checker@0.4.4: Package was renamed to 'grunt-jscs'  
* Added "time-grunt" to display the elapsed execution time of grunt tasks  
* To manage CSS vendor prefixes added "grunt-autoprefixer"  
* Improved Grunt task: minify all contents of a /minified/themes directory  
* Vendors prefixes is removed from the LESS files  
Reason: to manage CSS vendor prefixes added "grunt-autoprefixer"