### PR TITLE
Added grunt-dev-update

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -347,7 +347,16 @@ module.exports = function (grunt) {
 			all: {
 				'pre-commit': 'test'
 			}
-		}
+		},
+
+        devUpdate: {
+            main: {
+                options: {
+                    updateType: 'force',
+                    semver: false
+                }
+            }
+        }
 	});
 
 
@@ -366,6 +375,7 @@ module.exports = function (grunt) {
 	grunt.loadNpmTasks('grunt-saucelabs');
 	grunt.loadNpmTasks('grunt-webpack');
 	grunt.loadNpmTasks('grunt-githooks');
+    grunt.loadNpmTasks('grunt-dev-update');
 
 
 	grunt.registerTask('default', ['test']);
@@ -405,4 +415,9 @@ module.exports = function (grunt) {
 
 	// Alias dist to release for backwards compatibility
 	grunt.registerTask('dist', ['release']);
+
+    // Update dev dependencies
+    grunt.registerTask('dev-upd', [
+        'devUpdate:main'
+    ]);
 };

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "grunt-jscs": "^1.5.0",
     "grunt-saucelabs": "^8.6.0",
     "grunt-webpack": "^1.0.8",
+    "grunt-dev-update": "^1.1.0",
     "time-grunt": "^1.0.0"
   }
 }


### PR DESCRIPTION
A small but useful addition to the Grunt tasks, which automatically update outdated devDependencies and dependencies.

Install: **npm install** (in the project dir)
Use: **grunt dev-upd**