### PR TITLE
Remove e.stopPropagation(), use target check in handleDocumentClick instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ sceditor.sublime-workspace
 /dist
 /minified
 /docs
+/nbproject/

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ sceditor.sublime-workspace
 /dist
 /minified
 /docs
-/nbproject/

--- a/src/lib/SCEditor.js
+++ b/src/lib/SCEditor.js
@@ -1400,11 +1400,7 @@ define(function (require) {
 			$dropdown = $('<div class="sceditor-dropdown ' + cssClass + '" />')
 				.css(dropDownCss)
 				.append(content)
-				.appendTo($('body'))
-				.on('click focusin', function (e) {
-					// stop clicks within the dropdown from being handled
-					e.stopPropagation();
-				});
+				.appendTo($('body'));
 
 			// If try to focus the first input immediately IE will
 			// place the cursor at the start of the editor instead
@@ -1419,6 +1415,11 @@ define(function (require) {
 		 * @private
 		 */
 		handleDocumentClick = function (e) {
+			// ignore if click happens inside a dropdown
+			if ($(e.target).closest('.sceditor-dropdown').length) {
+				return;
+			}
+			
 			// ignore right clicks
 			if (e.which !== 3 && $dropdown) {
 				autoUpdate();

--- a/src/lib/templates.js
+++ b/src/lib/templates.js
@@ -81,7 +81,7 @@ define(function () {
 
 		youtube:
 			'<iframe width="560" height="315" ' +
-			'src="https://www.youtube.com/embed/{id}?wmode=opaque" ' +
+			'src="http://www.youtube.com/embed/{id}?wmode=opaque" ' +
 			'data-youtube-id="{id}" frameborder="0" allowfullscreen></iframe>'
 	};
 

--- a/src/lib/templates.js
+++ b/src/lib/templates.js
@@ -81,7 +81,7 @@ define(function () {
 
 		youtube:
 			'<iframe width="560" height="315" ' +
-			'src="http://www.youtube.com/embed/{id}?wmode=opaque" ' +
+			'src="https://www.youtube.com/embed/{id}?wmode=opaque" ' +
 			'data-youtube-id="{id}" frameborder="0" allowfullscreen></iframe>'
 	};
 

--- a/src/plugins/bbcode.js
+++ b/src/plugins/bbcode.js
@@ -2665,7 +2665,7 @@
 				return element ? '[youtube]' + element + '[/youtube]' : content;
 			},
 			html: '<iframe width="560" height="315" frameborder="0" ' +
-				'src="http://www.youtube.com/embed/{0}?wmode=opaque" ' +
+				'src="https://www.youtube.com/embed/{0}?wmode=opaque" ' +
 				'data-youtube-id="{0}" allowfullscreen></iframe>'
 		},
 		// END_COMMAND

--- a/src/plugins/bbcode.js
+++ b/src/plugins/bbcode.js
@@ -2665,7 +2665,7 @@
 				return element ? '[youtube]' + element + '[/youtube]' : content;
 			},
 			html: '<iframe width="560" height="315" frameborder="0" ' +
-				'src="https://www.youtube.com/embed/{0}?wmode=opaque" ' +
+				'src="http://www.youtube.com/embed/{0}?wmode=opaque" ' +
 				'data-youtube-id="{0}" allowfullscreen></iframe>'
 		},
 		// END_COMMAND

--- a/src/plugins/xhtml.js
+++ b/src/plugins/xhtml.js
@@ -212,7 +212,7 @@
 					function (id) {
 						editor.insertText(
 							'<iframe width="560" height="315" ' +
-							'src="http://www.youtube.com/embed/{id}?' +
+							'src="https://www.youtube.com/embed/{id}?' +
 							'wmode=opaque" data-youtube-id="' + id + '" ' +
 							'frameborder="0" allowfullscreen></iframe>'
 						);

--- a/src/plugins/xhtml.js
+++ b/src/plugins/xhtml.js
@@ -212,7 +212,7 @@
 					function (id) {
 						editor.insertText(
 							'<iframe width="560" height="315" ' +
-							'src="https://www.youtube.com/embed/{id}?' +
+							'src="http://www.youtube.com/embed/{id}?' +
 							'wmode=opaque" data-youtube-id="' + id + '" ' +
 							'frameborder="0" allowfullscreen></iframe>'
 						);


### PR DESCRIPTION
I wanted to bind to click event in a dropdown from outside code, but couldn't do it because of e.stopPropagation() in click's callback function. By removing it, and add check to handleDocumentClick to check if click event target is inside a dropdown, we can bind to click events in dropdown normally.