### PR TITLE
Add webpack and webpack-dev-server to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "grunt-jscs": "^1.8.0",
     "grunt-saucelabs": "^8.6.1",
     "grunt-webpack": "^1.0.8",
-    "time-grunt": "^1.2.0"
+    "time-grunt": "^1.2.0",
+    "webpack": "^1.13.0",
+    "webpack-dev-server": "^1.14.1"
   }
 }


### PR DESCRIPTION
> Peer dependencies are not installed automatically any longer since npm@3.

So `grunt-webpack` is not correctly installed his `peerDependencies`.
More detail https://github.com/webpack/grunt-webpack/issues/68.