### PR TITLE
JQuery3 Upgrade

### DIFF
--- a/example/example.html
+++ b/example/example.html
@@ -7,7 +7,11 @@
 
 		<link rel="stylesheet" href="../minified/themes/default.min.css" type="text/css" media="all" />
 
-		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.js"></script>
+		<script
+		  src="https://code.jquery.com/jquery-3.1.0.min.js"
+		  integrity="sha256-cCueBR6CsyA4/9szpPfrX3s49M9vUU5BgtiJj06wt/s="
+		  crossorigin="anonymous"></script>
+
 		<script src="../minified/jquery.sceditor.bbcode.min.js"></script>
 
 		<style>

--- a/src/lib/SCEditor.js
+++ b/src/lib/SCEditor.js
@@ -1,4 +1,4 @@
-define(function (require) {
+﻿define(function (require) {
 	'use strict';
 
 	var $             = require('jquery');
@@ -348,7 +348,7 @@ define(function (require) {
 			updateActiveButtons();
 
 			var loaded = function () {
-				$globalWin.unbind('load', loaded);
+				$globalWin.off('load', loaded);
 
 				if (options.autofocus) {
 					autofocus();
@@ -364,7 +364,7 @@ define(function (require) {
 
 				pluginManager.call('ready');
 			};
-			$globalWin.load(loaded);
+			$globalWin.on('load', loaded);
 			if (globalDoc.readyState && globalDoc.readyState === 'complete') {
 				loaded();
 			}
@@ -456,7 +456,7 @@ define(function (require) {
 				$wysiwygBody.height('100%');
 
 				if (!IE_VER) {
-					$wysiwygBody.bind('touchend', base.focus);
+					$wysiwygBody.on('touchend', base.focus);
 				}
 			}
 
@@ -477,8 +477,8 @@ define(function (require) {
 		initOptions = function () {
 			// auto-update original textbox on blur if option set to true
 			if (options.autoUpdate) {
-				$wysiwygBody.bind('blur', autoUpdate);
-				$sourceEditor.bind('blur', autoUpdate);
+				$wysiwygBody.on('blur', autoUpdate);
+				$sourceEditor.on('blur', autoUpdate);
 			}
 
 			if (options.rtl === null) {
@@ -488,7 +488,7 @@ define(function (require) {
 			base.rtl(!!options.rtl);
 
 			if (options.autoExpand) {
-				$wysiwygDoc.bind('keyup', base.expandToContent);
+				$wysiwygDoc.on('keyup', base.expandToContent);
 			}
 
 			if (options.resizeEnabled) {
@@ -514,10 +514,10 @@ define(function (require) {
 			$globalDoc.click(handleDocumentClick);
 
 			$(original.form)
-				.bind('reset', handleFormReset)
+				.on('reset', handleFormReset)
 				.submit(base.updateOriginal);
 
-			$globalWin.bind('resize orientationChanged', handleWindowResize);
+			$globalWin.on('resize orientationChanged', handleWindowResize);
 
 			$wysiwygBody
 				.keypress(handleKeyPress)
@@ -526,9 +526,9 @@ define(function (require) {
 				.keyup(appendNewLine)
 				.blur(valueChangedBlur)
 				.keyup(valueChangedKeyUp)
-				.bind('paste', handlePasteEvt)
-				.bind(CHECK_SELECTION_EVENTS, checkSelectionChanged)
-				.bind(EVENTS_TO_FORWARD, handleEvent);
+				.on('paste', handlePasteEvt)
+				.on(CHECK_SELECTION_EVENTS, checkSelectionChanged)
+				.on(EVENTS_TO_FORWARD, handleEvent);
 
 			if (options.emoticonsCompat && globalWin.getSelection) {
 				$wysiwygBody.keyup(emoticonsCheckWhitespace);
@@ -538,22 +538,22 @@ define(function (require) {
 				.blur(valueChangedBlur)
 				.keyup(valueChangedKeyUp)
 				.keydown(handleKeyDown)
-				.bind(EVENTS_TO_FORWARD, handleEvent);
+				.on(EVENTS_TO_FORWARD, handleEvent);
 
 			$wysiwygDoc
 				.mousedown(handleMouseDown)
 				.blur(valueChangedBlur)
-				.bind(CHECK_SELECTION_EVENTS, checkSelectionChanged)
-				.bind('beforedeactivate keyup mouseup', saveRange)
+				.on(CHECK_SELECTION_EVENTS, checkSelectionChanged)
+				.on('beforedeactivate keyup mouseup', saveRange)
 				.keyup(appendNewLine)
 				.focus(function () {
 					lastRange = null;
 				});
 
 			$editorContainer
-				.bind('selectionchanged', checkNodeChanged)
-				.bind('selectionchanged', updateActiveButtons)
-				.bind('selectionchanged valuechanged nodechanged', handleEvent);
+				.on('selectionchanged', checkNodeChanged)
+				.on('selectionchanged', updateActiveButtons)
+				.on('selectionchanged valuechanged nodechanged', handleEvent);
 		};
 
 		/**
@@ -753,8 +753,8 @@ define(function (require) {
 
 				$cover.hide();
 				$editorContainer.removeClass('resizing').height('auto');
-				$globalDoc.unbind(moveEvents, mouseMoveFunc);
-				$globalDoc.unbind(endEvents, mouseUpFunc);
+				$globalDoc.off(moveEvents, mouseMoveFunc);
+				$globalDoc.off(endEvents, mouseUpFunc);
 
 				e.preventDefault();
 			};
@@ -762,7 +762,7 @@ define(function (require) {
 			$editorContainer.append($grip);
 			$editorContainer.append($cover.hide());
 
-			$grip.bind('touchstart mousedown', function (e) {
+			$grip.on('touchstart mousedown', function (e) {
 				// iOS uses window.event
 				if (e.type === 'touchstart') {
 					e      = globalWin.event;
@@ -779,8 +779,8 @@ define(function (require) {
 
 				$editorContainer.addClass('resizing');
 				$cover.show();
-				$globalDoc.bind(moveEvents, mouseMoveFunc);
-				$globalDoc.bind(endEvents, mouseUpFunc);
+				$globalDoc.on(moveEvents, mouseMoveFunc);
+				$globalDoc.on(endEvents, mouseUpFunc);
 
 				// The resize cover will not fill the container in
 				// IE6 unless a height is specified.
@@ -1326,22 +1326,22 @@ define(function (require) {
 			pluginManager = null;
 
 			if ($dropdown) {
-				$dropdown.unbind().remove();
+				$dropdown.off().remove();
 			}
 
-			$globalDoc.unbind('click', handleDocumentClick);
-			$globalWin.unbind('resize orientationChanged', handleWindowResize);
+			$globalDoc.off('click', handleDocumentClick);
+			$globalWin.off('resize orientationChanged', handleWindowResize);
 
 			$(original.form)
-				.unbind('reset', handleFormReset)
-				.unbind('submit', base.updateOriginal);
+				.off('reset', handleFormReset)
+				.off('submit', base.updateOriginal);
 
-			$wysiwygBody.unbind();
-			$wysiwygDoc.unbind().find('*').remove();
+			$wysiwygBody.off();
+			$wysiwygDoc.off().find('*').remove();
 
-			$sourceEditor.unbind().remove();
+			$sourceEditor.off().remove();
 			$toolbar.remove();
-			$editorContainer.unbind().find('*').unbind().remove();
+			$editorContainer.off().find('*').off().remove();
 			$editorContainer.remove();
 
 			$original
@@ -1554,7 +1554,7 @@ define(function (require) {
 		 */
 		base.closeDropDown = function (focus) {
 			if ($dropdown) {
-				$dropdown.unbind().remove();
+				$dropdown.off().remove();
 				$dropdown = null;
 			}
 
@@ -2724,11 +2724,11 @@ define(function (require) {
 					// Also allows unbinding without unbinding the editors own
 					// event handlers.
 					if (!excludeWysiwyg) {
-						$editorContainer.bind('scewys' + events[i], handler);
+						$editorContainer.on('scewys' + events[i], handler);
 					}
 
 					if (!excludeSource) {
-						$editorContainer.bind('scesrc' + events[i], handler);
+						$editorContainer.on('scesrc' + events[i], handler);
 					}
 
 					// Start sending value changed events
@@ -2766,11 +2766,11 @@ define(function (require) {
 			while (i--) {
 				if ($.isFunction(handler)) {
 					if (!excludeWysiwyg) {
-						$editorContainer.unbind('scewys' + events[i], handler);
+						$editorContainer.off('scewys' + events[i], handler);
 					}
 
 					if (!excludeSource) {
-						$editorContainer.unbind('scesrc' + events[i], handler);
+						$editorContainer.off('scesrc' + events[i], handler);
 					}
 				}
 			}
@@ -2803,7 +2803,7 @@ define(function (require) {
 		 */
 		base.blur = function (handler, excludeWysiwyg, excludeSource) {
 			if ($.isFunction(handler)) {
-				base.bind('blur', handler, excludeWysiwyg, excludeSource);
+				base.on('blur', handler, excludeWysiwyg, excludeSource);
 			} else if (!base.sourceMode()) {
 				$wysiwygBody.blur();
 			} else {
@@ -2837,7 +2837,7 @@ define(function (require) {
 		 */
 		base.focus = function (handler, excludeWysiwyg, excludeSource) {
 			if ($.isFunction(handler)) {
-				base.bind('focus', handler, excludeWysiwyg, excludeSource);
+				base.on('focus', handler, excludeWysiwyg, excludeSource);
 			} else if (!base.inSourceMode()) {
 				var container,
 					rng = rangeHelper.selectedRange();
@@ -2898,7 +2898,7 @@ define(function (require) {
 		 * @since 1.4.1
 		 */
 		base.keyDown = function (handler, excludeWysiwyg, excludeSource) {
-			return base.bind('keydown', handler, excludeWysiwyg, excludeSource);
+			return base.on('keydown', handler, excludeWysiwyg, excludeSource);
 		};
 
 		/**
@@ -2917,7 +2917,7 @@ define(function (require) {
 		 */
 		base.keyPress = function (handler, excludeWysiwyg, excludeSource) {
 			return base
-				.bind('keypress', handler, excludeWysiwyg, excludeSource);
+				.on('keypress', handler, excludeWysiwyg, excludeSource);
 		};
 
 		/**
@@ -2935,7 +2935,7 @@ define(function (require) {
 		 * @since 1.4.1
 		 */
 		base.keyUp = function (handler, excludeWysiwyg, excludeSource) {
-			return base.bind('keyup', handler, excludeWysiwyg, excludeSource);
+			return base.on('keyup', handler, excludeWysiwyg, excludeSource);
 		};
 
 		/**
@@ -2952,7 +2952,7 @@ define(function (require) {
 		 * @since 1.4.1
 		 */
 		base.nodeChanged = function (handler) {
-			return base.bind('nodechanged', handler, false, true);
+			return base.on('nodechanged', handler, false, true);
 		};
 
 		/**
@@ -2968,7 +2968,7 @@ define(function (require) {
 		 * @since 1.4.1
 		 */
 		base.selectionChanged = function (handler) {
-			return base.bind('selectionchanged', handler, false, true);
+			return base.on('selectionchanged', handler, false, true);
 		};
 
 		/**
@@ -2994,7 +2994,7 @@ define(function (require) {
 		 */
 		base.valueChanged = function (handler, excludeWysiwyg, excludeSource) {
 			return base
-				.bind('valuechanged', handler, excludeWysiwyg, excludeSource);
+				.on('valuechanged', handler, excludeWysiwyg, excludeSource);
 		};
 
 		/**
@@ -3181,7 +3181,7 @@ define(function (require) {
 					});
 
 				currentEmoticons = [];
-				$wysiwygBody.unbind('keypress', emoticonsKeyPress);
+				$wysiwygBody.off('keypress', emoticonsKeyPress);
 
 				triggerValueChanged();
 			}


### PR DESCRIPTION
SCEditor was breaking when used with JQuery3 due to using deprecated methods (.load, .ready, .bind, .unbind, .delegate, .undelegate). See https://jquery.com/upgrade-guide/3.0/ for more information.

To fix this I updated these function calls to use the recommended .on and .off functions. The example/example.html page has also been updated to use the JQuery3 CDN (see https://code.jquery.com/)