### PR TITLE
Improve the filtering of emtpy nodes (xhtml plugin)

### DIFF
--- a/src/plugins/xhtml.js
+++ b/src/plugins/xhtml.js
@@ -734,7 +734,7 @@
 
 			while (childrenLength--) {
 				if (!isEmpty(childNodes[childrenLength],
-					!node.previousSibling && !node.nextSibling)) {
+					excludeBr && !node.previousSibling && !node.nextSibling)) {
 					return false;
 				}
 			}
@@ -747,20 +747,23 @@
 		 * tags are white listed it will remove any tags that
 		 * are black listed.
 		 *
-		 * @param  {Node} node
+		 * @param  {Node} rootNode
 		 * @return {Void}
 		 * @private
 		 */
-		removeTags = function (node) {
-			dom.traverse(node, function (node) {
+		removeTags = function (rootNode) {
+			dom.traverse(rootNode, function (node) {
 				var	remove,
 					tagName         = node.nodeName.toLowerCase(),
-					empty           = tagName !== 'iframe' && isEmpty(node),
 					parentNode      = node.parentNode,
 					nodeType        = node.nodeType,
 					isBlock         = !dom.isInline(node),
 					previousSibling = node.previousSibling,
 					nextSibling     = node.nextSibling,
+					isTopLevel      = parentNode === rootNode,
+					noSiblings      = !previousSibling && !nextSibling,
+					empty           = tagName !== 'iframe' && isEmpty(node,
+						isTopLevel && noSiblings && tagName !== 'br'),
 					document        = node.ownerDocument,
 					allowedtags     = sceditorPlugins.xhtml.allowedTags,
 					disallowedTags  = sceditorPlugins.xhtml.disallowedTags;

--- a/tests/unit/plugins/xhtml.js
+++ b/tests/unit/plugins/xhtml.js
@@ -79,6 +79,12 @@ define([
 		);
 
 		assert.htmlEqual(
+			this.filterHtml('<div><strong><br /></strong></div>'),
+			'',
+			'Single div with single strong with br'
+		);
+
+		assert.htmlEqual(
 			this.filterHtml('<span><br /></span>'),
 			'',
 			'Single span with br'
@@ -123,6 +129,12 @@ define([
 			this.filterHtml('<div>test</div><div><br /></div>'),
 			'<div>\n\ttest\n</div>\n<div>\n\t<br />\n</div>',
 			'Div with br as line seperator'
+		);
+
+		assert.htmlEqual(
+			this.filterHtml('<div><strong>test</strong></div><div><strong><br /></strong></div>'),
+			'<div>\n\t<strong>test</strong>\n</div>\n<div>\n\t<strong><br /></strong>\n</div>',
+			'Div with strong with br as line seperator'
 		);
 
 		assert.htmlEqual(


### PR DESCRIPTION
xhtml plugin filters the following html like the below:

```html
<p><strong>foo</strong><p>
<p><strong><br></strong></p>
```

```html
<p><strong>foo</strong><p>
```

This is because `<strong><br></strong>` is considered as empty dom.

But this doesn't seem consistent with the following example:

```html
<p>foo<p>
<p><br></p>
```

This becomes:

```html
<p>foo<p>
<p><br></p>
```

(does not change)

In this case `<p><br></p>` works as a line separator and isn't considered empty.

I think in the former example we should keep `<p><strong><br></strong></p>` as well because this dom is created by the editor as an empty paragragh when an user is writing in `<strong>` context.

To achieve the above I changed the handling of `excludeBr` flag of `isEmpty` function and pass it as true only when all parents (including top level one below the root node) don't have any siblings. (I also exlucde the case that top level node itself is `<br />` because this shouldn't be removed according to the test cases.)

This change doesn't break any existing test cases and passes the cases I added (which are similar to the first example.)

Thanks