### PR TITLE
Replace only "CTRL" by "CTRL or CMD" to mac user

### DIFF
--- a/src/lib/SCEditor.js
+++ b/src/lib/SCEditor.js
@@ -3354,7 +3354,7 @@
 				character = SPECIAL_KEYS[which] ||
 					String.fromCharCode(which).toLowerCase();
 
-			if (e.ctrlKey||e.metaKey) {
+			if (e.ctrlKey || e.metaKey) {
 				shortcut.push('ctrl');
 			}
 

--- a/src/lib/SCEditor.js
+++ b/src/lib/SCEditor.js
@@ -3354,7 +3354,7 @@
 				character = SPECIAL_KEYS[which] ||
 					String.fromCharCode(which).toLowerCase();
 
-			if (e.ctrlKey) {
+			if (e.ctrlKey||e.metaKey) {
 				shortcut.push('ctrl');
 			}
 


### PR DESCRIPTION
In mac, it's CMD+Z to undo