### PR TITLE
Fixed stacking of link,image,youtube and email

### DIFF
--- a/src/lib/defaultCommands.js
+++ b/src/lib/defaultCommands.js
@@ -475,6 +475,11 @@ define(function (require) {
 						insert: editor._('Insert')
 					}, true);
 
+				// Get highlighted image if any.
+				var	$current = $(editor.currentNode()),
+					$anchor  = $current.is('img') ? $current :
+					$current.children('img').first();
+
 				content.find('.button').click(function (e) {
 					var	val    = content.find('#image').val(),
 						width  = content.find('#width').val(),
@@ -500,6 +505,17 @@ define(function (require) {
 				});
 
 				editor.createDropDown(caller, 'insertimage', content);
+
+				// If an image is highlighted insert details in dropdown.
+				if ($anchor.attr('width')) {
+					content.find('#width').val($anchor.attr('width'));
+				}
+				if ($anchor.attr('height')) {
+					content.find('#height').val($anchor.attr('height'));
+				}
+				if ($anchor.attr('src')) {
+					content.find('#image').val($anchor.attr('src'));
+				}
 			},
 			tooltip: 'Insert an image'
 		},
@@ -515,6 +531,11 @@ define(function (require) {
 						insert: editor._('Insert')
 					}, true);
 
+				// Get highlighted email if any.
+				var	$current = $(editor.currentNode()),
+					$anchor  = $current.is('a') ? $current :
+					$current.parents('a').first();
+
 				content.find('.button').click(function (e) {
 					var val         = content.find('#email').val(),
 						description = content.find('#des').val();
@@ -527,11 +548,19 @@ define(function (require) {
 							description) {
 							description = description || val;
 
-							editor.wysiwygEditorInsertHtml(
-								'<a href="' + 'mailto:' + val + '">' +
-									description +
-								'</a>'
-							);
+							// Replace existing Link, instead of stacking.
+							if ($anchor.length) {
+								if (description) {
+									$anchor.attr('href', description);
+								}
+								$anchor.attr('href', val);
+							} else {
+								editor.wysiwygEditorInsertHtml(
+									'<a href="' + 'mailto:' + val + '">' +
+										description +
+									'</a>'
+								);
+							}
 						} else {
 							editor.execCommand('createlink', 'mailto:' + val);
 						}
@@ -542,6 +571,19 @@ define(function (require) {
 				});
 
 				editor.createDropDown(caller, 'insertemail', content);
+
+				// Check it is an email address.
+				if ($anchor.attr('href') &&
+					$anchor.attr('href').substr(0, 7) === 'mailto:') {
+					// Get details of highlighted and put in drop down.
+					if ($anchor.attr('href')) {
+						content.find('#email')
+							.val($anchor.attr('href').substring(7));
+					}
+					if ($anchor.text()) {
+						content.find('#des').val($anchor.text());
+					}
+				}
 			},
 			tooltip: 'Insert an email'
 		},
@@ -557,6 +599,12 @@ define(function (require) {
 					desc: editor._('Description (optional):'),
 					ins: editor._('Insert')
 				}, true);
+
+				// Get highlighted link if any.
+				var	$current = $(editor.currentNode()),
+					$anchor  = $current.is('a') ? $current :
+					$current.parents('a').first();
+
 				var $link = content.find('#link');
 				var $description = content.find('#des');
 
@@ -574,9 +622,17 @@ define(function (require) {
 						if (!editor.getRangeHelper().selectedHtml() || text) {
 							text = text || url;
 
-							editor.wysiwygEditorInsertHtml(
-								'<a href="' + url + '">' + text + '</a>'
-							);
+							// Replace existing Link, instead of stacking.
+							if ($anchor.length) {
+								if (text) {
+									$anchor.attr('href', text);
+								}
+								$anchor.attr('href', url);
+							} else {
+								editor.wysiwygEditorInsertHtml(
+									'<a href="' + url + '">' + text + '</a>'
+								);
+							}
 						} else {
 							editor.execCommand('createlink', url);
 						}
@@ -596,6 +652,18 @@ define(function (require) {
 				});
 
 				editor.createDropDown(caller, 'insertlink', content);
+
+				// Check it is an email address.
+				if ($anchor.attr('href') &&
+					$anchor.attr('href').substr(0, 7) !== 'mailto:') {
+				// Get details of highlighted and put in drop down.
+					if ($anchor.attr('href')) {
+						content.find('#link').val($anchor.attr('href'));
+					}
+					if ($anchor.text()) {
+						content.find('#des').val($anchor.text());
+					}
+				}
 			},
 			tooltip: 'Insert a link'
 		},
@@ -736,6 +804,11 @@ define(function (require) {
 						insert: editor._('Insert')
 					}, true);
 
+				// Get highlighted link if any.
+				var	$current = $(editor.currentNode()),
+					$anchor  = $current.is('iframe') ? $current :
+					$current.children('iframe').first();
+
 				content.find('.button').click(function (e) {
 					var val = content
 						.find('#link')
@@ -751,7 +824,13 @@ define(function (require) {
 						}
 
 						if (/^[a-zA-Z0-9_\-]{11}$/.test(val)) {
-							handleIdFunc(val);
+							// Replace existing Link, instead of stacking.
+							if ($anchor.length) {
+								$anchor.attr('src',
+									'https://www.youtube.com/embed/' + val + '?wmode=opaque');
+							} else {
+								handleIdFunc(val);
+							}
 						} else {
 							/*global alert:false*/
 							alert('Invalid YouTube video');
@@ -763,6 +842,11 @@ define(function (require) {
 				});
 
 				editor.createDropDown(caller, 'insertlink', content);
+
+				// Get details of highlighted and put in drop down.
+				if ($anchor.attr('src')) {
+					content.find('#link').val($anchor.attr('src'));
+				}
 			},
 			exec: function (caller) {
 				var editor = this;


### PR DESCRIPTION
Solved an issue where if you highlight a link you have inserted and go to insert another link in its place using the drop down in WYSIWYG mode, this will stop the element stacking. Example current output:

```
<a href="http://1stlink.com">
    <a href="http://2ndlink.com">DESCRIPTION</a>
</a>
```

In addition to this, the previous link you have highlighted to change will display the link details in the drop down allowing you to edit the previous link instead of having to retype everything again. The same goes for modifying email, images and YouTube Videos.

I have used https:// for YouTube as http will be classed as insecure in 2017.