### PR TITLE
#fixes 545 Replaced <p> with div for body content.

### DIFF
--- a/src/lib/SCEditor.js
+++ b/src/lib/SCEditor.js
@@ -1996,7 +1996,7 @@
 		 */
 		base.setWysiwygEditorValue = function (value) {
 			if (!value) {
-				value = '<p>' + (IE_VER ? '' : '<br />') + '</p>';
+				value = '<div>' + (IE_VER ? '' : '<br />') + '</div>';
 			}
 
 			$wysiwygBody[0].innerHTML = value;


### PR DESCRIPTION
As stated in issue replaced the tags that get inserted into the document on load and when creating a new line. This solves the issue of quotes splitting and removing <p> that would get replaced with <div> so just use div instead as default for content lines.