### PR TITLE
Inline code implementation

### DIFF
--- a/src/formats/bbcode.js
+++ b/src/formats/bbcode.js
@@ -168,6 +168,9 @@
 		code: {
 			txtExec: ['[code]', '[/code]']
 		},
+		c: {
+			txtExec: ['[c]', '[/c]']
+		},
 		image: {
 			txtExec: function (caller, selected) {
 				var	editor  = this;
@@ -715,6 +718,44 @@
 		},
 		// END_COMMAND
 
+		// START_COMMAND: c (inline code)
+		c: {
+			tags: {
+				c: null
+			},
+			isInline: true,
+			allowedChildren: ['#'],
+			format: '[c]{0}[/c]',
+			html: '<span class="inline-code" data-inline-code="1">{0}</span>'
+		},
+		// END_COMMAND
+
+		// START_COMMAND: c (inline code)
+		span: {
+			tags: {
+				span: {
+					'data-inline-code': null
+				}
+			},
+			isInline: true,
+			allowedChildren: ['#'],
+			format: function (element, content) {
+				if (this.opts.allowInlineCode) {
+					return '[c]' + content + '[/c]';
+				} else {
+					return content;
+				}
+			},
+			html: function (token, attrs, content) {
+				if (this.opts.allowInlineCode) {
+					return '<span class="inline-code" data-inline-code="1">' +
+						content + '</span>';
+				} else {
+					return content;
+				}
+			}
+		},
+		// END_COMMAND
 
 		// START_COMMAND: Left
 		left: {
@@ -2256,7 +2297,8 @@
 			ol: ['li', 'ol', 'ul'],
 			table: ['tr'],
 			tr: ['td', 'th'],
-			code: ['br', 'p', 'div']
+			code: ['br', 'p', 'div'],
+			span: ['br']
 		};
 
 		/**

--- a/src/formats/xhtml.js
+++ b/src/formats/xhtml.js
@@ -114,6 +114,10 @@
 		code: {
 			txtExec: ['<code>', '</code>']
 		},
+		c: {
+			txtExec: ['<span class="inline-code" data-inline-code="1">',
+				'</span>']
+		},
 		image: {
 			txtExec: function (caller, selected) {
 				var	editor  = this;

--- a/src/lib/defaultCommands.js
+++ b/src/lib/defaultCommands.js
@@ -442,10 +442,33 @@ var defaultCmds = {
 	// START_COMMAND: Code
 	code: {
 		exec: function () {
-			this.wysiwygEditorInsertHtml(
-				'<code>',
-				(IE_BR_FIX ? '' : '<br />') + '</code>'
-			);
+			var editor = this;
+			var range = editor.getRangeHelper().selectedRange();
+			var selected = editor.getRangeHelper().selectedHtml();
+			var wholeLine = false;
+
+			// Check if the whole line was selected
+			// It could be the whole text of the text type node (3)
+			// or innerHTML of an element node (1) if there were some markups
+			// in the text, so its containted in a paragraph <p>...</p>
+			if ((range.commonAncestorContainer.nodeType === 3 &&
+				range.commonAncestorContainer.wholeText === selected) ||
+				(range.commonAncestorContainer.nodeType === 1 &&
+				range.commonAncestorContainer.innerHTML === selected)) {
+				wholeLine = true;
+			}
+
+			if (editor.opts.allowInlineCode && !wholeLine && selected &&
+				selected.length > 0 && !selected.includes('<p>')) {
+				this.wysiwygEditorInsertHtml(
+					'<span class="inline-code" data-inline-code="1">', '</span>'
+				);
+			} else {
+				this.wysiwygEditorInsertHtml(
+					'<code>',
+					(IE_BR_FIX ? '' : '<br />') + '</code>'
+				);
+			}
 		},
 		tooltip: 'Code'
 	},

--- a/src/lib/defaultOptions.js
+++ b/src/lib/defaultOptions.js
@@ -357,5 +357,14 @@ export default {
 	 *
 	 * @type {Object}
 	 */
-	dropDownCss: { }
+	dropDownCss: { },
+
+	/**
+	 * Set to true to allow creation of inline code segments wrapped with
+	 * [c]code[/c] tags
+	 *
+	 * @type {boolean}
+	 */
+	allowInlineCode: true
+
 };

--- a/src/themes/content/default.css
+++ b/src/themes/content/default.css
@@ -59,6 +59,16 @@ code {
 	margin: .25em 0;
 }
 
+span.inline-code {
+	display: inline;
+	background: #f1f1f1;
+	border: 1px solid #C9D2D8;
+	font-size: 0.9em;
+	font-style: normal;
+	white-space: pre;
+	padding: 0 3px;
+}
+
 blockquote {
 	background: #fff7d9;
 	margin: .25em 0;

--- a/tests/unit/formats/bbcode.js
+++ b/tests/unit/formats/bbcode.js
@@ -109,7 +109,7 @@ QUnit.test('HTML to BBCode trim', function (assert) {
 QUnit.module('plugins/bbcode - HTML to BBCode', {
 	beforeEach: function () {
 		this.mockEditor = {
-			opts: $.extend({}, defaultOptions)
+			opts: $.extend({}, defaultOptions, { allowInlineCode: true })
 		};
 
 		this.format = new sceditor.formats.bbcode();
@@ -766,7 +766,7 @@ QUnit.test('Quote', function (assert) {
 });
 
 
-QUnit.test('Code', function (assert) {
+QUnit.test('Code - block', function (assert) {
 	assert.equal(
 		this.htmlToBBCode('<code>Testing 1.2.3....</code>'),
 		'[code]Testing 1.2.3....[/code]\n',
@@ -778,6 +778,36 @@ QUnit.test('Code', function (assert) {
 			'<code><b>ignore this</b> Testing 1.2.3....</code>'
 		),
 		'[code]ignore this Testing 1.2.3....[/code]\n',
+		'Code with styling'
+	);
+});
+
+
+QUnit.test('Code - inline', function (assert) {
+	this.mockEditor = {
+		opts: $.extend({}, defaultOptions, { allowInlineCode: true })
+	};
+
+	this.format = new sceditor.formats.bbcode();
+	this.format.init.call(this.mockEditor);
+
+	this.htmlToBBCode = function (html) {
+		return this.format.toSource(html, document);
+	};
+
+	assert.equal(
+		this.htmlToBBCode(
+			'text <span class="inline-code" data-inline-code="1">inline code</span> text'
+		),
+		'text [c]inline code[/c] text',
+		'Simple code'
+	);
+
+	assert.equal(
+		this.htmlToBBCode(
+			'text <span class="inline-code" data-inline-code="1"><b>ignore this</b> Testing 1.2.3....</span> text'
+		),
+		'text [c]ignore this Testing 1.2.3....[/c] text',
 		'Code with styling'
 	);
 });

--- a/tests/unit/formats/bbcode.parser.js
+++ b/tests/unit/formats/bbcode.parser.js
@@ -10,7 +10,10 @@ var IE_BR_STR = IE_BR_FIX ? '' : '<br />';
 
 QUnit.module('plugins/bbcode#Parser', {
 	beforeEach: function () {
-		this.parser = new sceditor.BBCodeParser({});
+		this.parser = new sceditor.BBCodeParser({
+			parserOptions: {},
+			allowInlineCode: false
+		});
 	}
 });
 
@@ -864,7 +867,7 @@ QUnit.test('Quote', function (assert) {
 });
 
 
-QUnit.test('Code', function (assert) {
+QUnit.test('Code - block', function (assert) {
 	assert.htmlEqual(
 		this.parser.toHTML('[code]Testing 1.2.3....[/code]'),
 		'<code>Testing 1.2.3....' + IE_BR_STR + '</code>',
@@ -874,6 +877,25 @@ QUnit.test('Code', function (assert) {
 	assert.htmlEqual(
 		this.parser.toHTML('[code]Testing [b]test[/b][/code]'),
 		'<code>Testing [b]test[/b]' + IE_BR_STR + '</code>',
+		'Normal'
+	);
+});
+
+
+QUnit.test('Code - inline', function (assert) {
+	this.parser = new sceditor.BBCodeParser({
+		parserOptions: {}, allowInlineCode: true
+	});
+
+	assert.htmlEqual(
+		this.parser.toHTML('text [c]inline code[/c] text'),
+		'<div>text <span class="inline-code" data-inline-code="1">inline code</span> text</div>\n',
+		'Normal'
+	);
+
+	assert.htmlEqual(
+		this.parser.toHTML('text [c]Testing [b]test[/b][/c] text'),
+		'<div>text <span class="inline-code" data-inline-code="1">Testing [b]test[/b]</span> text</div>\n',
 		'Normal'
 	);
 });


### PR DESCRIPTION
This PR include:
    Inline code tags
    [c][/c] tags are used
    The implementation is configurable by allowInlineCode option, disabled by default to keep current behaviour unchanged.

The decision whether the code will be inline:

    Some text was selected
    The selected text doesn't include the

    (full line was selected, or more than one line)
    Not the whole line was selected (happens when selecting a line from the beginning to the end, but the end of the line is not selected, so it's not catched by previous point)

Open issue:
Don't know how to prevent styling inside the inline code segment, something that is done in the [code][/code] segment already.
The styling is stripped after parsing, but the [code] prevents the user buttons while in the segment...