### PR TITLE
Remove empty "sceditor-nlf" paragraph in XHTML format

### DIFF
--- a/src/formats/xhtml.js
+++ b/src/formats/xhtml.js
@@ -736,6 +736,12 @@
 							/br/i.test(firstChild.nodeName))) {
 							// Mark as empty,it will be removed by the next code
 							empty = true;
+						} else {
+							node.classList.remove('sceditor-nlf');
+
+							if (!node.className) {
+								removeAttr(node, 'class');
+							}
 						}
 					}
 				}

--- a/src/formats/xhtml.js
+++ b/src/formats/xhtml.js
@@ -12,6 +12,12 @@
 (function (sceditor) {
 	'use strict';
 
+	var IE_VER = sceditor.ie;
+
+	// In IE < 11 a BR at the end of a block level element
+	// causes a double line break.
+	var IE_BR_FIX = IE_VER && IE_VER < 11;
+
 	var dom = sceditor.dom;
 	var utils = sceditor.utils;
 
@@ -707,6 +713,7 @@
 						isTopLevel && noSiblings && tagName !== 'br'),
 					document        = node.ownerDocument,
 					allowedTags     = xhtmlFormat.allowedTags,
+					firstChild   	= node.firstChild,
 					disallowedTags  = xhtmlFormat.disallowedTags;
 
 				// 3 = text node
@@ -718,6 +725,19 @@
 					tagName = '!cdata';
 				} else if (tagName === '!' || nodeType === 8) {
 					tagName = '!comment';
+				}
+
+				if (nodeType === 1) {
+					// skip empty nlf elements (new lines automatically
+					// added after block level elements like quotes)
+					if (is(node, '.sceditor-nlf')) {
+						if (!firstChild || (!IE_BR_FIX &&
+							node.childNodes.length === 1 &&
+							/br/i.test(firstChild.nodeName))) {
+							// Mark as empty,it will be removed by the next code
+							empty = true;
+						}
+					}
 				}
 
 				if (empty) {

--- a/tests/unit/formats/xhtml.js
+++ b/tests/unit/formats/xhtml.js
@@ -956,3 +956,41 @@ QUnit.test('Mozilla\'s junk attributes fix', function (assert) {
 		'_moz_editor_bogus_node attribute on div'
 	);
 });
+
+
+QUnit.test('Should remove empty nlf tags', function (assert) {
+	var IE_VER = sceditor.ie;
+
+	// In IE < 11 a BR at the end of a block level element
+	// causes a double line break.
+	var IE_BR_FIX = IE_VER && IE_VER < 11;
+
+	assert.htmlEqual(
+		this.filterStripWhiteSpace('<div class="sceditor-nlf"></div>'),
+		'',
+		'Empty'
+	);
+
+	if (!IE_BR_FIX) {
+		assert.htmlEqual(
+			this.filterStripWhiteSpace('<div class="sceditor-nlf"><br /></div>'),
+			'',
+			'Empty with BR'
+		);
+	}
+});
+
+QUnit.test('Should remove the nlf class from none empty nlf tags', function (assert) {
+	assert.htmlEqual(
+		this.filterStripWhiteSpace('<div class="sceditor-nlf">test</div>'),
+		'<div>test</div>',
+		'None empty'
+	);
+
+	assert.htmlEqual(
+		this.filterHtml('<div class="sceditor-nlf test">test</div>'),
+		'<div class="test">\n\ttest\n</div>',
+		'None empty with extra class'
+	);
+});
+


### PR DESCRIPTION
Updating XHTML format with the code from bbcode format to remove empty "sceditor-nlf" paragraphs.
Addresses #673 