### PR TITLE
Fix plugins initialization problems

### DIFF
--- a/src/lib/SCEditor.js
+++ b/src/lib/SCEditor.js
@@ -407,6 +407,15 @@ export default function SCEditor(original, userOptions) {
 		isRequired = original.required;
 		original.required = false;
 
+		// Plugins should be initiated before the formatters since plugin
+		// may add/change the handlers and format init should create cache
+		// with those changes
+		initPlugins();
+
+		// Plugins might change the commands, should re-build it
+		base.commands = utils
+			.extend(true, {}, (userOptions.commands || defaultCommands));
+
 		var FormatCtor = SCEditor.formats[options.format];
 		format = FormatCtor ? new FormatCtor() : {};
 		if ('init' in format) {
@@ -414,7 +423,6 @@ export default function SCEditor(original, userOptions) {
 		}
 
 		// create the editor
-		initPlugins();
 		initEmoticons();
 		initToolBar();
 		initEditor();


### PR DESCRIPTION
Plugins change defaultCommands and formatter handlers on initialization.
The internal commands list should be rebuild affter plugins initialization, as well as the formatter init, which builds cache based on the handlers that were added/changed by the plugins.