### PR TITLE
Fix going back in the browser causes content to be lost

### DIFF
--- a/src/lib/SCEditor.js
+++ b/src/lib/SCEditor.js
@@ -622,6 +622,7 @@ export default function SCEditor(original, userOptions) {
 		if (form) {
 			dom.on(form, 'reset', handleFormReset);
 			dom.on(form, 'submit', base.updateOriginal, dom.EVENT_CAPTURE);
+			dom.on(window, 'unload', base.updateOriginal, dom.EVENT_CAPTURE);
 		}
 
 		dom.on(wysiwygBody, 'keypress', handleKeyPress);
@@ -1373,6 +1374,7 @@ export default function SCEditor(original, userOptions) {
 		if (form) {
 			dom.off(form, 'reset', handleFormReset);
 			dom.off(form, 'submit', base.updateOriginal);
+			dom.off(window, 'unload', base.updateOriginal);
 		}
 
 		dom.remove(sourceEditor);


### PR DESCRIPTION
If you use the back button in your browser then go forward, all the content is lost.  This is because the information is not sent back to the original prior to unloading the page.  This change simply attaches a event to the unload for window and triggers the base update to occur.  The browser handles the rest if it supports remembering what was entered into the textarea.

Signed-off-by: jdarwood007 <unmonitored+github@sleepycode.com>