### PR TITLE
replaceEmoticons

### DIFF
--- a/src/lib/SCEditor.js
+++ b/src/lib/SCEditor.js
@@ -2071,6 +2071,21 @@ export default function SCEditor(original, userOptions) {
 	/**
 	 * Replaces any emoticon codes in the passed HTML
 	 * with their emoticon images
+	 *
+	 * @function
+	 * @name replaceEmoticons
+	 * @since XYZ
+	 * @memberOf SCEditor.prototype
+	 */
+	base.replaceEmoticons = function (el) {
+		if (options.emoticonsEnabled) {
+			emoticons
+				.replace(el, allEmoticons, options.emoticonsCompat);
+		}
+	};
+	/**
+	 * Replaces any emoticon codes in the passed HTML
+	 * with their emoticon images
 	 * @private
 	 */
 	replaceEmoticons = function () {


### PR DESCRIPTION
I made replaceEmoticons public and now to convert code from bbcode to HTML, we can just:

	let toDOM = function (bbcode) {
		let htmlCode = sceditor.instance(textarea).fromBBCode(bbcode);
		let dom = $.parseHTML(htmlCode)[0];
		sceditor.instance(textarea).replaceEmoticons(dom);
		return dom;
	}