### PR TITLE
to.style sometimes undefined copying into editor in copyCSS

### DIFF
--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -757,8 +757,11 @@ export function isInline(elm, includeCodeAsBlock) {
  * @param {HTMLElement} to
  */
 export function copyCSS(from, to) {
-	to.style.cssText = from.style.cssText + to.style.cssText;
+	if (to.style) {
+	  to.style.cssText = from.style.cssText + to.style.cssText;
+	}
 }
+
 
 /**
  * Fixes block level elements inside in inline elements.

--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -758,7 +758,7 @@ export function isInline(elm, includeCodeAsBlock) {
  */
 export function copyCSS(from, to) {
 	if (to.style) {
-	  to.style.cssText = from.style.cssText + to.style.cssText;
+		to.style.cssText = from.style.cssText + to.style.cssText;
 	}
 }
 


### PR DESCRIPTION
We've come across a case where copying formatted text over formatted text in the editor errors with to.style being undefined. This could do with a check to make sure style exists on the 'to' before we try to set anything on it.