### PR TITLE
SCEditor - Cross-site Scripting (XSS) - Fix:

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,9 @@
     "time-grunt": "^1.4.0",
     "webpack": "^4.6.0",
     "webpack-dev-server": "^3.1.3"
+  },
+  "dependencies": {
+    "dompurify": "^2.0.8",
+    "jsdom": "^16.2.0"
   }
 }

--- a/src/lib/defaultCommands.js
+++ b/src/lib/defaultCommands.js
@@ -3,6 +3,11 @@ import * as utils from './utils.js';
 import { ie as IE_VER } from './browser.js';
 import _tmpl from './templates.js';
 
+const createDOMPurify = require('dompurify');
+const { JSDOM } = require('jsdom');
+const window = new JSDOM('').window;
+const DOMPurify = createDOMPurify(window);
+
 // In IE < 11 a BR at the end of a block level element
 // causes a line break. In all other browsers it's collapsed.
 var IE_BR_FIX = IE_VER && IE_VER < 11;
@@ -420,7 +425,7 @@ var defaultCmds = {
 
 					html += '</table>';
 
-					editor.wysiwygEditorInsertHtml(html);
+					editor.wysiwygEditorInsertHtml(DOMPurify.sanitize(html));
 					editor.closeDropDown(true);
 					e.preventDefault();
 				}
@@ -502,7 +507,7 @@ var defaultCmds = {
 					}
 
 					editor.wysiwygEditorInsertHtml(
-						'<img' + attrs + ' src="' + url + '" />'
+						'<img' + DOMPurify.sanitize(attrs) + ' src="' + DOMPurify.sanitize(url) + '" />'
 					);
 				}
 			);
@@ -547,8 +552,8 @@ var defaultCmds = {
 
 					if (!editor.getRangeHelper().selectedHtml() || text) {
 						editor.wysiwygEditorInsertHtml(
-							'<a href="' + 'mailto:' + email + '">' +
-								(text || email) +
+							'<a href="' + 'mailto:' + DOMPurify.sanitize(email) + '">' +
+								(DOMPurify.sanitize(text) || DOMPurify.sanitize(email)) +
 							'</a>'
 						);
 					} else {
@@ -607,7 +612,7 @@ var defaultCmds = {
 					text = text || url;
 
 					editor.wysiwygEditorInsertHtml(
-						'<a href="' + url + '">' + text + '</a>'
+						'<a href="' + DOMPurify.sanitize(url) + '">' + DOMPurify.sanitize(text) + '</a>'
 					);
 				} else {
 					editor.execCommand('createlink', url);


### PR DESCRIPTION
https://github.com/mufeedvh fixed the vulnerability associated with Cross-site Scripting (XSS).
This fix is being submitted on behalf of https://github.com/mufeedvh - they have been awarded $25 for fixing the vulnerability through the huntr bug bounty program.
Think you could fix a vulnerability like this - get involved (https://huntr.dev).
Q | A
Version Affected | ALL
Bug Fix | YES
Further References | https://github.com/418sec/SCEditor/pull/2