### PR TITLE
Use dompurify internally to prevent XSS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,6 +2,8 @@
 module.exports = (grunt) => {
 	require('time-grunt')(grunt);
 	const istanbul = require('istanbul');
+	const nodeResolve = require('rollup-plugin-node-resolve');
+
 
 	grunt.event.on('qunit.coverage', function (data) {
 		const Report = istanbul.Report;
@@ -163,6 +165,13 @@ module.exports = (grunt) => {
 				external: ['jquery'],
 				globals: {
 					jquery: 'jQuery'
+				},
+				plugins: function () {
+					return [
+						nodeResolve({
+							module: true
+						})
+					];
 				}
 			},
 			build: {

--- a/package.json
+++ b/package.json
@@ -57,17 +57,17 @@
     "grunt-eslint": "^20.1.0",
     "grunt-githooks": "^0.6.0",
     "grunt-postcss": "^0.9.0",
-    "grunt-rollup": "^9.0.0",
+    "grunt-rollup": "^11.5.0",
     "grunt-saucelabs": "^9.0.0",
     "istanbul": "^0.4.5",
     "istanbul-instrumenter-loader": "^3.0.1",
     "postcss-clean": "^1.1.0",
     "time-grunt": "^1.4.0",
     "webpack": "^4.6.0",
-    "webpack-dev-server": "^3.1.3"
+    "webpack-dev-server": "^3.1.3",
+    "rollup-plugin-node-resolve": "^5.2.0"
   },
   "dependencies": {
-    "dompurify": "^2.0.8",
-    "jsdom": "^16.2.0"
+    "dompurify": "^2.0.8"
   }
 }

--- a/src/formats/bbcode.js
+++ b/src/formats/bbcode.js
@@ -798,7 +798,7 @@
 				return element ? '[youtube]' + element + '[/youtube]' : content;
 			},
 			html: '<iframe width="560" height="315" frameborder="0" ' +
-				'src="https://www.youtube.com/embed/{0}?wmode=opaque" ' +
+				'src="https://www.youtube-nocookie.com/embed/{0}?wmode=opaque" ' +
 				'data-youtube-id="{0}" allowfullscreen></iframe>'
 		},
 		// END_COMMAND

--- a/src/formats/xhtml.js
+++ b/src/formats/xhtml.js
@@ -1189,6 +1189,29 @@
 			conv: function (node) {
 				node.parentNode.removeChild(node);
 			}
+		},
+		{
+			tags: {
+				'*': {
+					'data-sce-target': null
+				}
+			},
+			conv: function (node) {
+				var rel = attr(node, 'rel') || '';
+				var target = attr(node, 'data-sce-target');
+
+				// Only allow the value _blank and only on links
+				if (target === '_blank' && is(node, 'a')) {
+					if (!/(^|\s)noopener(\s|$)/.test(rel)) {
+						attr(node, 'rel', 'noopener' + (rel ? ' ' + rel : ''));
+					}
+
+					attr(node, 'target', target);
+				}
+
+
+				removeAttr(node, 'data-sce-target');
+			}
 		}
 	];
 

--- a/src/lib/RangeHelper.js
+++ b/src/lib/RangeHelper.js
@@ -76,7 +76,7 @@ var outerText = function (range, isLeft, length) {
  * @class RangeHelper
  * @name RangeHelper
  */
-export default function RangeHelper(win, d) {
+export default function RangeHelper(win, d, sanitize) {
 	var	_createMarker, _prepareInput,
 		doc          = d || win.contentDocument || win.document,
 		startMarker  = 'sceditor-start-marker',
@@ -112,7 +112,7 @@ export default function RangeHelper(win, d) {
 
 		div           = dom.createElement('p', {}, doc);
 		node          = doc.createDocumentFragment();
-		div.innerHTML = html;
+		div.innerHTML = sanitize(html);
 
 		while (div.firstChild) {
 			dom.appendChild(node, div.firstChild);

--- a/src/lib/SCEditor.js
+++ b/src/lib/SCEditor.js
@@ -396,7 +396,7 @@ export default function SCEditor(original, userOptions) {
 		var allowedUrls = options.allowedIframeUrls;
 
 		if (data.tagName === 'iframe') {
-			var src = node.getAttribute('src') || '';
+			var src = dom.attr(node, 'src') || '';
 
 			for (var i = 0; i < allowedUrls.length; i++) {
 				var url = allowedUrls[i];
@@ -416,6 +416,16 @@ export default function SCEditor(original, userOptions) {
 		}
 	});
 
+	// Convert target attribute into data-sce-target attributes so XHTML format
+	// can allow them
+	domPurify.addHook('afterSanitizeAttributes', function (node) {
+		if ('target' in node) {
+			dom.attr(node, 'data-sce-target', dom.attr(node, 'target'));
+		}
+
+		dom.removeAttr(node, 'target');
+	});
+
 	/**
 	 * Sanitize HTML to avoid XSS
 	 *
@@ -426,7 +436,7 @@ export default function SCEditor(original, userOptions) {
 	function sanitize(html) {
 		return domPurify.sanitize(html, {
 			ADD_TAGS: ['iframe'],
-			ADD_ATTR: ['allowfullscreen', 'frameborder']
+			ADD_ATTR: ['allowfullscreen', 'frameborder', 'target']
 		});
 	};
 

--- a/src/lib/SCEditor.js
+++ b/src/lib/SCEditor.js
@@ -1568,7 +1568,7 @@ export default function SCEditor(original, userOptions) {
 		dom.trigger(editorContainer, 'pasteraw', data);
 
 		if (data.html) {
-			// Sanatise again in case plugins modified the HTML
+			// Sanitize again in case plugins modified the HTML
 			pasteArea.innerHTML = sanitize(data.html);
 
 			// fix any invalid nesting

--- a/src/lib/SCEditor.js
+++ b/src/lib/SCEditor.js
@@ -385,8 +385,9 @@ export default function SCEditor(original, userOptions) {
 	 *
 	 * @param {string} html
 	 * @return {string} html
+	 * @private
 	 */
-	base.sanitize = function (html) {
+	function sanitize(html) {
 		// This is added as a method so plugins can use it without having to
 		// include their own version of DOMPurify
 		return DOMPurify.sanitize(html);
@@ -571,7 +572,7 @@ export default function SCEditor(original, userOptions) {
 		dom.attr(sourceEditor, 'tabindex', tabIndex);
 		dom.attr(wysiwygEditor, 'tabindex', tabIndex);
 
-		rangeHelper = new RangeHelper(wysiwygWindow, null, base.sanitize);
+		rangeHelper = new RangeHelper(wysiwygWindow, null, sanitize);
 
 		// load any textarea value into the editor
 		dom.hide(original);
@@ -1523,7 +1524,7 @@ export default function SCEditor(original, userOptions) {
 			}
 			// Call plugins here with file?
 			data.text = data['text/plain'];
-			data.html = data['text/html'];
+			data.html = sanitize(data['text/html']);
 
 			handlePasteData(data);
 		// If contentsFragment exists then we are already waiting for a
@@ -1550,7 +1551,7 @@ export default function SCEditor(original, userOptions) {
 
 				rangeHelper.restoreRange();
 
-				handlePasteData({ html: html });
+				handlePasteData({ html: sanitize(html) });
 			}, 0);
 		}
 	};
@@ -1567,7 +1568,8 @@ export default function SCEditor(original, userOptions) {
 		dom.trigger(editorContainer, 'pasteraw', data);
 
 		if (data.html) {
-			pasteArea.innerHTML = base.sanitize(data.html);
+			// Sanatise again in case plugins modified the HTML
+			pasteArea.innerHTML = sanitize(data.html);
 
 			// fix any invalid nesting
 			dom.fixNesting(pasteArea);
@@ -2045,7 +2047,7 @@ export default function SCEditor(original, userOptions) {
 			value = '<p>' + (IE_VER ? '' : '<br />') + '</p>';
 		}
 
-		wysiwygBody.innerHTML = base.sanitize(value);
+		wysiwygBody.innerHTML = sanitize(value);
 		replaceEmoticons();
 
 		appendNewLine();

--- a/src/lib/defaultCommands.js
+++ b/src/lib/defaultCommands.js
@@ -4,11 +4,6 @@ import * as escape from './escape.js';
 import { ie as IE_VER } from './browser.js';
 import _tmpl from './templates.js';
 
-const createDOMPurify = require('dompurify');
-const { JSDOM } = require('jsdom');
-const window = new JSDOM('').window;
-const DOMPurify = createDOMPurify(window);
-
 // In IE < 11 a BR at the end of a block level element
 // causes a line break. In all other browsers it's collapsed.
 var IE_BR_FIX = IE_VER && IE_VER < 11;
@@ -426,7 +421,7 @@ var defaultCmds = {
 
 					html += '</table>';
 
-					editor.wysiwygEditorInsertHtml(DOMPurify.sanitize(html));
+					editor.wysiwygEditorInsertHtml(html);
 					editor.closeDropDown(true);
 					e.preventDefault();
 				}

--- a/src/lib/defaultOptions.js
+++ b/src/lib/defaultOptions.js
@@ -343,6 +343,19 @@ export default {
 	disableBlockRemove: false,
 
 	/**
+	 * Array of allowed URL (should be either strings or regex) for iframes.
+	 *
+	 * If it's a string then iframes where the start of the src matches the
+	 * specified string will be allowed.
+	 *
+	 * If it's a regex then iframes where the src matches the regex will be
+	 * allowed.
+	 *
+	 * @type {Array}
+	 */
+	allowedIframeUrls: [],
+
+	/**
 	 * BBCode parser options, only applies if using the editor in BBCode
 	 * mode.
 	 *

--- a/src/lib/templates.js
+++ b/src/lib/templates.js
@@ -86,7 +86,7 @@ var _templates = {
 
 	youtube:
 		'<iframe width="560" height="315" frameborder="0" allowfullscreen ' +
-		'src="https://www.youtube.com/embed/{id}?wmode=opaque&start={time}" ' +
+		'src="https://www.youtube-nocookie.com/embed/{id}?wmode=opaque&start={time}" ' +
 		'data-youtube-id="{id}"></iframe>'
 };
 

--- a/tests/unit/formats/bbcode.parser.js
+++ b/tests/unit/formats/bbcode.parser.js
@@ -919,7 +919,7 @@ QUnit.test('YouTube', function (assert) {
 	assert.htmlEqual(
 		this.parser.toHTML('[youtube]xyz[/youtube]'),
 		'<div><iframe width="560" height="315" ' +
-			'src="https://www.youtube.com/embed/xyz?wmode=opaque" ' +
+			'src="https://www.youtube-nocookie.com/embed/xyz?wmode=opaque" ' +
 			'data-youtube-id="xyz" frameborder="0" allowfullscreen>' +
 			'</iframe></div>\n',
 		'Normal'

--- a/tests/unit/init.js
+++ b/tests/unit/init.js
@@ -14,24 +14,12 @@
 					}
 				};
 			}
-			if (prop === 'nextSibling') {
+			if (prop === 'nextSibling' ||
+				prop === 'childNodes' ||
+				prop === 'parentNode') {
 				return {
 					value: function () {
-						return this.nextSibling;
-					}
-				};
-			}
-			if (prop === 'childNodes') {
-				return {
-					value: function () {
-						return this.childNodes;
-					}
-				};
-			}
-			if (prop === 'parentNode') {
-				return {
-					value: function () {
-						return this.parentNode;
+						return this[prop];
 					}
 				};
 			}

--- a/tests/unit/init.js
+++ b/tests/unit/init.js
@@ -2,6 +2,44 @@
 	// Report QUnit results to SauceLabs
 	var log = [];
 
+	// dompurify PhantomJS support
+	// See: https://github.com/cure53/DOMPurify/issues/502#issuecomment-763651764
+	if ('_phantom' in window) {
+		const orig = Object.getOwnPropertyDescriptor;
+		Object.getOwnPropertyDescriptor = function (obj, prop) {
+			if (prop === 'cloneNode') {
+				return {
+					value: function () {
+						return this.cloneNode();
+					}
+				};
+			}
+			if (prop === 'nextSibling') {
+				return {
+					value: function () {
+						return this.nextSibling;
+					}
+				};
+			}
+			if (prop === 'childNodes') {
+				return {
+					value: function () {
+						return this.childNodes;
+					}
+				};
+			}
+			if (prop === 'parentNode') {
+				return {
+					value: function () {
+						return this.parentNode;
+					}
+				};
+			}
+
+			return orig(obj, prop);
+		};
+	}
+
 	QUnit.done(function (testResults) {
 		var tests = [];
 

--- a/tests/unit/lib/RangeHelper.js
+++ b/tests/unit/lib/RangeHelper.js
@@ -1,6 +1,7 @@
 import RangeHelper from 'src/lib/RangeHelper.js';
 import * as utils from 'tests/unit/utils.js';
 import rangy from 'rangy';
+import DOMPurify from 'dompurify';
 
 var editableDiv, rangeHelper;
 
@@ -20,7 +21,7 @@ QUnit.module('lib/RangeHelper', {
 
 		fixture.appendChild(editableDiv);
 
-		rangeHelper = new RangeHelper(window, document);
+		rangeHelper = new RangeHelper(window, document, DOMPurify.sanitize);
 	}
 });
 

--- a/tests/unit/lib/SCEditor.js
+++ b/tests/unit/lib/SCEditor.js
@@ -510,3 +510,23 @@ QUnit.test('Insert image XSS', function (assert) {
 		}, 1);
 	}, true);
 });
+
+QUnit.test('Insert HTML filter JS', function (assert) {
+	var done = assert.async();
+
+	reloadEditor({
+		format: 'bbcode'
+	});
+
+	var called = false;
+	sceditor.getBody().xss = function () {
+		called = true;
+	};
+	sceditor.wysiwygEditorInsertHtml('<img src="http://url.to.file.which/not.exist" onerror=body.xss();>');
+	sceditor.getBody().addEventListener('error', function () {
+		setTimeout(function () {
+			assert.notOk(called);
+			done();
+		}, 1);
+	}, true);
+});

--- a/tests/unit/lib/SCEditor.js
+++ b/tests/unit/lib/SCEditor.js
@@ -530,3 +530,27 @@ QUnit.test('Insert HTML filter JS', function (assert) {
 		}, 1);
 	}, true);
 });
+
+
+QUnit.test('Allow target=blank links', function (assert) {
+	reloadEditor({
+		format: 'xhtml'
+	});
+
+	sceditor.val(
+		'<a href="#" target="_blank">blank</a>' +
+		'<a href="#" rel="  noopener" target="_blank">safe</a>' +
+		'<a href="#" rel="noreferrer" target="_blank">referer</a>' +
+		'<a href="#" rel="noreferrernoopener" target="_blank">invalid noopener</a>' +
+		'<a href="#" target="blank">removed</a>' +
+		'<img src="removed.jpg" target="_blank" />'
+	);
+	assert.htmlEqual(sceditor.val(), '<p>\n	' +
+		'<a href=\"#\" rel=\"noopener\" target=\"_blank\">blank</a>' +
+		'<a href=\"#\" rel=\"noopener\" target=\"_blank\">safe</a>' +
+		'<a href=\"#\" rel=\"noopener noreferrer\" target=\"_blank\">referer</a>' +
+		'<a href=\"#\" rel=\"noopener noreferrernoopener\" target=\"_blank\">invalid noopener</a>' +
+		'<a href="#">removed</a>' +
+		'<img src=\"removed.jpg\" />\n' +
+	'</p>');
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,18 @@
 # yarn lockfile v1
 
 
+"@types/node@*":
+  version "14.14.27"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.27.tgz#c7127f8da0498993e13b1a42faf1303d3110d2f2"
+  integrity sha512-Ecfmo4YDQPwuqTCl1yBxLV5ihKfRlkBmzUEDcfIRvDxOTGQEeikr317Ln7Gcv0tjA8dVgKI3rniqW2G1OyKDng==
+
+"@types/resolve@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
+  integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
+  dependencies:
+    "@types/node" "*"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -629,6 +641,11 @@ buffer@^4.3.0:
 builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+
+builtin-modules@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.2.0.tgz#45d5db99e7ee5e6bc4f362e008bf917ab5049887"
+  integrity sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==
 
 builtin-status-codes@^3.0.0:
   version "3.0.0"
@@ -1275,6 +1292,11 @@ domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
 
+dompurify@^2.0.8:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.2.6.tgz#54945dc5c0b45ce5ae228705777e8e59d7b2edc4"
+  integrity sha512-7b7ZArhhH0SP6W2R9cqK6RjaU82FZ2UPM7RO8qN1b1wyvC/NY1FNWcX1Pu00fFOAnzEORtwXe4bPaClg6pUybQ==
+
 duplexify@^3.4.2, duplexify@^3.5.3:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.5.4.tgz#4bb46c1796eabebeec4ca9a2e66b808cb7a3d8b4"
@@ -1496,6 +1518,11 @@ estraverse@^1.9.1:
 estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
+
+estree-walker@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
+  integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -1929,6 +1956,11 @@ fsevents@^1.1.2:
     nan "^2.9.2"
     node-pre-gyp "^0.9.0"
 
+fsevents@~2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fstream@^1.0.0, fstream@^1.0.2:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
@@ -2230,11 +2262,12 @@ grunt-postcss@^0.9.0:
     diff "^3.0.0"
     postcss "^6.0.11"
 
-grunt-rollup@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/grunt-rollup/-/grunt-rollup-9.0.0.tgz#a3f9c26a603f1a5ddd6ec65f2a65cf0e4eaca6d5"
+grunt-rollup@^11.5.0:
+  version "11.5.0"
+  resolved "https://registry.yarnpkg.com/grunt-rollup/-/grunt-rollup-11.5.0.tgz#ec1bdda97827054434de21535ac236144f9a50d4"
+  integrity sha512-Xa/1g0G4HlMIAsJYLZgDEDi8w2jZ5sLpo6XKezJqGdpTGe8qGWcXG7kopiyCUYiXs3LLv58y/DhGIXwbkCAkvQ==
   dependencies:
-    rollup "0.54.0"
+    rollup "^2.32.0"
 
 grunt-saucelabs@^9.0.0:
   version "9.0.0"
@@ -2372,6 +2405,13 @@ has@^1.0.1:
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
   dependencies:
     function-bind "^1.0.2"
+
+has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+  dependencies:
+    function-bind "^1.1.1"
 
 hash-base@^3.0.0:
   version "3.0.4"
@@ -2708,6 +2748,13 @@ is-callable@^1.1.1, is-callable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
 
+is-core-module@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
+  integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
+  dependencies:
+    has "^1.0.3"
+
 is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
@@ -2801,6 +2848,11 @@ is-glob@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
   dependencies:
     is-extglob "^2.1.1"
+
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
+  integrity sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
 
 is-number@^2.1.0:
   version "2.1.0"
@@ -3898,6 +3950,11 @@ path-key@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
+path-parse@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
@@ -4418,6 +4475,14 @@ resolve@1.1.x, resolve@~1.1.0:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
+resolve@^1.11.1:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
+  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
+  dependencies:
+    is-core-module "^2.2.0"
+    path-parse "^1.0.6"
+
 restore-cursor@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
@@ -4459,9 +4524,30 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rollup@0.54.0:
-  version "0.54.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.54.0.tgz#0641b8154ba02706464285d2ead924c486b48ba9"
+rollup-plugin-node-resolve@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz#730f93d10ed202473b1fb54a5997a7db8c6d8523"
+  integrity sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==
+  dependencies:
+    "@types/resolve" "0.0.8"
+    builtin-modules "^3.1.0"
+    is-module "^1.0.0"
+    resolve "^1.11.1"
+    rollup-pluginutils "^2.8.1"
+
+rollup-pluginutils@^2.8.1:
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
+  integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
+  dependencies:
+    estree-walker "^0.6.1"
+
+rollup@^2.32.0:
+  version "2.39.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.39.0.tgz#be4f98c9e421793a8fec82c854fb567c35e22ab6"
+  integrity sha512-+WR3bttcq7zE+BntH09UxaW3bQo3vItuYeLsyk4dL2tuwbeSKJuvwiawyhEnvRdRgrII0Uzk00FpctHO/zB1kw==
+  optionalDependencies:
+    fsevents "~2.3.1"
 
 run-async@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Based off PR #767 this uses dompurify internally to sanitise all HTML.

It would add ~7kb to the compressed size and add dompurify as a dependency but should make all methods of inserting HTML into the editor safe from XSS.

Closes     #767