### PR TITLE
Drop IE and legacy Edge support

### DIFF
--- a/example/example.html
+++ b/example/example.html
@@ -51,7 +51,7 @@ Give it a try! :)
 
 [ul][li]A simple list[/li][li]list item 2[/li][/ul]
 
-If you are using IE9+ or any non-IE browser just type [b]:[/b]) and it should be converted into :) as you type.</textarea>
+Just type [b]:[/b]) and it should be converted into :) as you type.</textarea>
 
 				<p>If you are using IE9+ or any other browser then it should automatically replace
 					:) and other emoticon codes with theit emoticon images.</p>

--- a/example/example.html
+++ b/example/example.html
@@ -53,8 +53,6 @@ Give it a try! :)
 
 Just type [b]:[/b]) and it should be converted into :) as you type.</textarea>
 
-				<p>If you are using IE9+ or any other browser then it should automatically replace
-					:) and other emoticon codes with theit emoticon images.</p>
 			</div>
 
 			<div>

--- a/src/formats/bbcode.js
+++ b/src/formats/bbcode.js
@@ -1800,7 +1800,7 @@
 		function convertToHTML(tokens, isRoot) {
 			var	undef, token, bbcode, content, html, needsBlockWrap,
 				blockWrapOpen, isInline, lastChild,
-				ret = [];
+				ret = '';
 
 			isInline = function (bbcode) {
 				return (!bbcode || (bbcode.isHtmlInline !== undef ?
@@ -1850,26 +1850,26 @@
 					}
 				} else if (token.type === TOKEN_NEWLINE) {
 					if (!isRoot) {
-						ret.push('<br />');
+						ret += '<br />';
 						continue;
 					}
 
 					// If not already in a block wrap then start a new block
 					if (!blockWrapOpen) {
-						ret.push('<div>');
+						ret += '<div>';
 					}
 
-					ret.push('<br />');
+					ret += '<br />';
 
 					// Normally the div acts as a line-break with by moving
 					// whatever comes after onto a new line.
 					// If this is the last token, add an extra line-break so it
 					// shows as there will be nothing after it.
 					if (!tokens.length) {
-						ret.push('<br />');
+						ret += '<br />';
 					}
 
-					ret.push('</div>\n');
+					ret += '</div>\n';
 					blockWrapOpen = false;
 					continue;
 				// content
@@ -1879,21 +1879,21 @@
 				}
 
 				if (needsBlockWrap && !blockWrapOpen) {
-					ret.push('<div>');
+					ret += '<div>';
 					blockWrapOpen = true;
 				} else if (!needsBlockWrap && blockWrapOpen) {
-					ret.push('</div>\n');
+					ret += '</div>\n';
 					blockWrapOpen = false;
 				}
 
-				ret.push(html);
+				ret += html;
 			}
 
 			if (blockWrapOpen) {
-				ret.push('</div>\n');
+				ret += '</div>\n';
 			}
 
-			return ret.join('');
+			return ret;
 		}
 
 		/**
@@ -1925,10 +1925,7 @@
 		function convertToBBCode(toks) {
 			var	token, attr, bbcode, isBlock, isSelfClosing, quoteType,
 				breakBefore, breakStart, breakEnd, breakAfter,
-				// Create an array of strings which are joined together
-				// before being returned as this is faster in slow browsers.
-				// (Old versions of IE).
-				ret = [];
+				ret = '';
 
 			while (toks.length > 0) {
 				if (!(token = toks.shift())) {
@@ -1960,75 +1957,75 @@
 					base.opts.quoteType || QuoteType.auto;
 
 				if (!bbcode && token.type === TOKEN_OPEN) {
-					ret.push(token.val);
+					ret += token.val;
 
 					if (token.children) {
-						ret.push(convertToBBCode(token.children));
+						ret += convertToBBCode(token.children);
 					}
 
 					if (token.closing) {
-						ret.push(token.closing.val);
+						ret += token.closing.val;
 					}
 				} else if (token.type === TOKEN_OPEN) {
 					if (breakBefore) {
-						ret.push('\n');
+						ret += '\n';
 					}
 
 					// Convert the tag and it's attributes to BBCode
-					ret.push('[' + token.name);
+					ret += '[' + token.name;
 					if (token.attrs) {
 						if (token.attrs.defaultattr) {
-							ret.push('=', quote(
+							ret += '=' + quote(
 								token.attrs.defaultattr,
 								quoteType,
 								'defaultattr'
-							));
+							);
 
 							delete token.attrs.defaultattr;
 						}
 
 						for (attr in token.attrs) {
 							if (token.attrs.hasOwnProperty(attr)) {
-								ret.push(' ', attr, '=',
-									quote(token.attrs[attr], quoteType, attr));
+								ret += ' ' + attr + '=' +
+									quote(token.attrs[attr], quoteType, attr);
 							}
 						}
 					}
-					ret.push(']');
+					ret += ']';
 
 					if (breakStart) {
-						ret.push('\n');
+						ret += '\n';
 					}
 
 					// Convert the tags children to BBCode
 					if (token.children) {
-						ret.push(convertToBBCode(token.children));
+						ret += convertToBBCode(token.children);
 					}
 
 					// add closing tag if not self closing
 					if (!isSelfClosing && !bbcode.excludeClosing) {
 						if (breakEnd) {
-							ret.push('\n');
+							ret += '\n';
 						}
 
-						ret.push('[/' + token.name + ']');
+						ret += '[/' + token.name + ']';
 					}
 
 					if (breakAfter) {
-						ret.push('\n');
+						ret += '\n';
 					}
 
 					// preserve whatever was recognized as the
 					// closing tag if it is a self closing tag
 					if (token.closing && isSelfClosing) {
-						ret.push(token.closing.val);
+						ret += token.closing.val;
 					}
 				} else {
-					ret.push(token.val);
+					ret += token.val;
 				}
 			}
 
-			return ret.join('');
+			return ret;
 		}
 
 		/**

--- a/src/formats/bbcode.js
+++ b/src/formats/bbcode.js
@@ -25,12 +25,6 @@
 	var extend = utils.extend;
 	var each   = utils.each;
 
-	var IE_VER = sceditor.ie;
-
-	// In IE < 11 a BR at the end of a block level element
-	// causes a double line break.
-	var IE_BR_FIX = IE_VER && IE_VER < 11;
-
 	var EMOTICON_DATA_ATTR = 'data-sceditor-emoticon';
 
 	var getEditorCommand = sceditor.command.get;
@@ -878,7 +872,7 @@
 				return;
 			}
 
-			if (IE_BR_FIX || (node.childNodes.length !== 1 ||
+			if ((node.childNodes.length !== 1 ||
 				!is(node.firstChild, 'br'))) {
 				while ((next = node.firstChild)) {
 					output.insertBefore(next, node);
@@ -1831,12 +1825,9 @@
 							isInline(bbcodeHandlers[lastChild.name]) &&
 							!bbcode.isPreFormatted &&
 							!bbcode.skipLastLineBreak) {
-							// Add placeholder br to end of block level elements
-							// in all browsers apart from IE < 9 which handle
-							// new lines differently and doesn't need one.
-							if (!IE_BR_FIX) {
-								content += '<br />';
-							}
+							// Add placeholder br to end of block level
+							// elements
+							content += '<br />';
 						}
 
 						if (!isFunction(bbcode.html)) {
@@ -1868,11 +1859,7 @@
 						ret.push('<div>');
 					}
 
-					// Putting BR in a div in IE causes it
-					// to do a double line break.
-					if (!IE_BR_FIX) {
-						ret.push('<br />');
-					}
+					ret.push('<br />');
 
 					// Normally the div acts as a line-break with by moving
 					// whatever comes after onto a new line.
@@ -2371,7 +2358,6 @@
 
 				// If it's the last block of an inline that is the last
 				// child of a block then it shouldn't cause a line break
-				// except in IE < 11
 				// <block><inline><br></inline></block>
 				do {
 					parent          = element.parentNode;
@@ -2384,10 +2370,7 @@
 				// If this block is:
 				//	* Not the last child of a block level element
 				//	* Is a <li> tag (lists are blocks)
-				//	* Is IE < 11 and the tag is BR. IE < 11 never collapses BR
-				//	  tags.
-				if (!isLastBlockChild || tag === 'li' ||
-					(tag === 'br' && IE_BR_FIX)) {
+				if (!isLastBlockChild || tag === 'li') {
 					content += '\n';
 				}
 
@@ -2510,12 +2493,8 @@
 					if (nodeType === 1) {
 						// skip empty nlf elements (new lines automatically
 						// added after block level elements like quotes)
-						if (is(node, '.sceditor-nlf')) {
-							if (!firstChild || (!IE_BR_FIX &&
-								node.childNodes.length === 1 &&
-								/br/i.test(firstChild.nodeName))) {
-								return;
-							}
+						if (is(node, '.sceditor-nlf') && !firstChild) {
+							return;
 						}
 
 						// don't convert iframe contents

--- a/src/formats/xhtml.js
+++ b/src/formats/xhtml.js
@@ -12,12 +12,6 @@
 (function (sceditor) {
 	'use strict';
 
-	var IE_VER = sceditor.ie;
-
-	// In IE < 11 a BR at the end of a block level element
-	// causes a double line break.
-	var IE_BR_FIX = IE_VER && IE_VER < 11;
-
 	var dom = sceditor.dom;
 	var utils = sceditor.utils;
 
@@ -312,14 +306,7 @@
 		function serializeNode(node, parentIsPre) {
 			switch (node.nodeType) {
 				case 1: // element
-					var tagName = node.nodeName.toLowerCase();
-
-					// IE comment
-					if (tagName === '!') {
-						handleComment(node);
-					} else {
-						handleElement(node, parentIsPre);
-					}
+					handleElement(node, parentIsPre);
 					break;
 
 				case 3: // text
@@ -731,8 +718,7 @@
 					// skip empty nlf elements (new lines automatically
 					// added after block level elements like quotes)
 					if (is(node, '.sceditor-nlf')) {
-						if (!firstChild || (!IE_BR_FIX &&
-							node.childNodes.length === 1 &&
+						if (!firstChild || (node.childNodes.length === 1 &&
 							/br/i.test(firstChild.nodeName))) {
 							// Mark as empty,it will be removed by the next code
 							empty = true;

--- a/src/icons/material.js
+++ b/src/icons/material.js
@@ -109,13 +109,6 @@
 					if (!isSourceMode && currentNode) {
 						color = currentNode.ownerDocument
 							.queryCommandValue('forecolor');
-
-						// Needed for IE
-						if (parseInt(color) === color) {
-							// eslint-disable-next-line
-							color = ((color & 0x0000ff) << 16) | (color & 0x00ff00) | ((color & 0xff0000) >>> 16);
-							color = '#' + ('000000' + color.toString(16)).slice(-6);
-						}
 					}
 
 					dom.css(colorPath, 'fill', color);

--- a/src/icons/monocons.js
+++ b/src/icons/monocons.js
@@ -89,13 +89,6 @@
 					if (!isSourceMode && currentNode) {
 						color = currentNode.ownerDocument
 							.queryCommandValue('forecolor');
-
-						// Needed for IE
-						if (parseInt(color) === color) {
-							// eslint-disable-next-line
-							color = ((color & 0x0000ff) << 16) | (color & 0x00ff00) | ((color & 0xff0000) >>> 16);
-							color = '#' + ('000000' + color.toString(16)).slice(-6);
-						}
 					}
 
 					dom.css(colorPath, 'fill', color);

--- a/src/lib/RangeHelper.js
+++ b/src/lib/RangeHelper.js
@@ -1,10 +1,5 @@
 import * as dom from './dom.js';
 import * as escape from './escape.js';
-import { ie as IE_VER } from './browser.js';
-
-// In IE < 11 a BR at the end of a block level element
-// causes a line break. In all other browsers it's collapsed.
-var IE_BR_FIX = IE_VER && IE_VER < 11;
 
 
 /**
@@ -508,7 +503,7 @@ export default function RangeHelper(win, d, sanitize) {
 		// Check if cursor is set after a BR when the BR is the only
 		// child of the parent. In Firefox this causes a line break
 		// to occur when something is typed. See issue #321
-		if (!IE_BR_FIX && range.collapsed && container &&
+		if (range.collapsed && container &&
 			!dom.isInline(container, true)) {
 
 			lastChild = container.lastChild;

--- a/src/lib/browser.js
+++ b/src/lib/browser.js
@@ -1,44 +1,6 @@
 var USER_AGENT = navigator.userAgent;
 
 /**
- * Detects the version of IE is being used if any.
- *
- * Will be the IE version number or undefined if the
- * browser is not IE.
- *
- * Source: https://gist.github.com/527683 with extra code
- * for IE 10 & 11 detection.
- *
- * @function
- * @name ie
- * @type {number}
- */
-var ie = (function () {
-	var	undef,
-		v   = 3,
-		doc = document,
-		div = doc.createElement('div'),
-		all = div.getElementsByTagName('i');
-
-	do {
-		div.innerHTML = '<!--[if gt IE ' + (++v) + ']><i></i><![endif]-->';
-	} while (all[0]);
-
-	// Detect IE 10 as it doesn't support conditional comments.
-	if ((doc.documentMode && doc.all && window.atob)) {
-		v = 10;
-	}
-
-	// Detect IE 11
-	if (v === 4 && doc.documentMode) {
-		v = 11;
-	}
-
-	return v > 4 ? v : undef;
-}());
-
-
-/**
  * Detects if the browser is iOS
  *
  * Needed to fix iOS specific bugs
@@ -60,6 +22,8 @@ export var ios = /iPhone|iPod|iPad| wosbrowser\//i.test(USER_AGENT);
 export var isWysiwygSupported = (function () {
 	var	match, isUnsupported;
 
+	// IE is the only browser to support documentMode
+	var ie = !!window.document.documentMode;
 	var legacyEdge = '-ms-ime-align' in document.documentElement.style;
 
 	var div = document.createElement('div');

--- a/src/lib/browser.js
+++ b/src/lib/browser.js
@@ -13,7 +13,7 @@ var USER_AGENT = navigator.userAgent;
  * @name ie
  * @type {number}
  */
-export var ie = (function () {
+var ie = (function () {
 	var	undef,
 		v   = 3,
 		doc = document,
@@ -37,7 +37,6 @@ export var ie = (function () {
 	return v > 4 ? v : undef;
 }());
 
-export var edge = '-ms-ime-align' in document.documentElement.style;
 
 /**
  * Detects if the browser is iOS
@@ -61,8 +60,10 @@ export var ios = /iPhone|iPod|iPad| wosbrowser\//i.test(USER_AGENT);
 export var isWysiwygSupported = (function () {
 	var	match, isUnsupported;
 
+	var legacyEdge = '-ms-ime-align' in document.documentElement.style;
+
 	var div = document.createElement('div');
-	div.contentEditable = true ;
+	div.contentEditable = true;
 
 	// Check if the contentEditable attribute is supported
 	if (!('contentEditable' in document.documentElement) ||
@@ -123,8 +124,8 @@ export var isWysiwygSupported = (function () {
 		isUnsupported = false;
 	}
 
-	// IE <= 9 is not supported any more
-	if (ie <= 9) {
+	// IE and legacy edge are not supported any more
+	if (ie || legacyEdge) {
 		isUnsupported = true;
 	}
 

--- a/src/lib/defaultCommands.js
+++ b/src/lib/defaultCommands.js
@@ -1,12 +1,7 @@
 import * as dom from './dom.js';
 import * as utils from './utils.js';
 import * as escape from './escape.js';
-import { ie as IE_VER } from './browser.js';
 import _tmpl from './templates.js';
-
-// In IE < 11 a BR at the end of a block level element
-// causes a line break. In all other browsers it's collapsed.
-var IE_BR_FIX = IE_VER && IE_VER < 11;
 
 /**
  * Fixes a bug in FF where it sometimes wraps
@@ -414,7 +409,7 @@ var defaultCmds = {
 					html += Array(rows + 1).join(
 						'<tr>' +
 							Array(cols + 1).join(
-								'<td>' + (IE_BR_FIX ? '' : '<br />') + '</td>'
+								'<td><br /></td>'
 							) +
 						'</tr>'
 					);
@@ -445,7 +440,7 @@ var defaultCmds = {
 		exec: function () {
 			this.wysiwygEditorInsertHtml(
 				'<code>',
-				(IE_BR_FIX ? '' : '<br />') + '</code>'
+				'<br /></code>'
 			);
 		},
 		tooltip: 'Code'
@@ -545,9 +540,6 @@ var defaultCmds = {
 				editor,
 				caller,
 				function (email, text) {
-					// needed for IE to reset the last range
-					editor.focus();
-
 					if (!editor.getRangeHelper().selectedHtml() || text) {
 						editor.wysiwygEditorInsertHtml(
 							'<a href="' +
@@ -601,18 +593,10 @@ var defaultCmds = {
 			var editor = this;
 
 			defaultCmds.link._dropDown(editor, caller, function (url, text) {
-				// needed for IE to restore the last range
-				editor.focus();
-
-				// If there is no selected text then must set the URL as
-				// the text. Most browsers do this automatically, sadly
-				// IE doesn't.
 				if (text || !editor.getRangeHelper().selectedHtml()) {
-					text = text || url;
-
 					editor.wysiwygEditorInsertHtml(
 						'<a href="' + escape.entities(url) + '">' +
-							escape.entities(text) +
+							escape.entities(text || url) +
 						'</a>'
 					);
 				} else {
@@ -661,7 +645,7 @@ var defaultCmds = {
 				end    = null;
 			// if not add a newline to the end of the inserted quote
 			} else if (this.getRangeHelper().selectedHtml() === '') {
-				end = (IE_BR_FIX ? '' : '<br />') + end;
+				end = '<br />' + end;
 			}
 
 			this.wysiwygEditorInsertHtml(before, end);

--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -976,7 +976,7 @@ export function getOffset(node) {
  * @return {string}
  */
 export function getStyle(elm, property) {
-	var	direction, styleValue,
+	var	styleValue,
 		elmStyle = elm.style;
 
 	if (!cssPropertyNameCache[property]) {
@@ -988,18 +988,10 @@ export function getStyle(elm, property) {
 
 	// Add an exception for text-align
 	if ('textAlign' === property) {
-		direction  = elmStyle.direction;
 		styleValue = styleValue || css(elm, property);
 
 		if (css(elm.parentNode, property) === styleValue ||
 			css(elm, 'display') !== 'block' || is(elm, 'hr,th')) {
-			return '';
-		}
-
-		// IE changes text-align to the same as the current direction
-		// so skip unless its not the same
-		if ((/right/i.test(styleValue) && direction === 'rtl') ||
-			(/left/i.test(styleValue) && direction === 'ltr')) {
 			return '';
 		}
 	}

--- a/src/lib/emoticons.js
+++ b/src/lib/emoticons.js
@@ -32,12 +32,7 @@ export function checkWhitespace(node, rangeHelper) {
 		var range = rangeHelper.cloneSelected();
 		var rangeStart = -1;
 		var rangeStartContainer = range.startContainer;
-		var previousText = prev.nodeValue;
-
-		// For IE's HTMLPhraseElement
-		if (previousText === null) {
-			previousText = prev.innerText || '';
-		}
+		var previousText = prev.nodeValue || '';
 
 		previousText += dom.data(emoticon, 'sceditor-emoticon');
 

--- a/src/lib/templates.js
+++ b/src/lib/templates.js
@@ -12,13 +12,6 @@ var _templates = {
 		'<!DOCTYPE html>' +
 		'<html{attrs}>' +
 			'<head>' +
-				'<style>.ie * {min-height: auto !important} ' +
-					'.ie table td {height:15px} ' +
-					// Target Edge (fixes edge issues)
-					'@supports (-ms-ime-align:auto) { ' +
-						'* { min-height: auto !important; } ' +
-					'}' +
-					'</style>' +
 				'<meta http-equiv="Content-Type" ' +
 					'content="text/html;charset={charset}" />' +
 				'<link rel="stylesheet" type="text/css" href="{style}" />' +

--- a/src/sceditor.js
+++ b/src/sceditor.js
@@ -26,7 +26,6 @@ window.sceditor = {
 	commands: defaultCommands,
 	defaultOptions: defaultOptions,
 
-	ie: browser.ie,
 	ios: browser.ios,
 	isWysiwygSupported: browser.isWysiwygSupported,
 

--- a/tests/unit/formats/bbcode.js
+++ b/tests/unit/formats/bbcode.js
@@ -1,12 +1,6 @@
 import defaultOptions from 'src/lib/defaultOptions.js';
 import * as utils from 'tests/unit/utils.js';
-import * as browser from 'src/lib/browser.js';
 import 'src/formats/bbcode.js';
-
-// In IE < 11 a BR at the end of a block level element
-// causes a line break. In all other browsers it's collapsed.
-var IE_BR_FIX = browser.ie && browser.ie < 11;
-var IE_BR_STR = IE_BR_FIX ? '' : '<br />';
 
 
 QUnit.module('plugins/bbcode', {
@@ -63,7 +57,7 @@ QUnit.test('BBcode to HTML trim', function (assert) {
 		this.format.toHtml(
 			'\n\n[quote]test[/quote]\n\n'
 		),
-		'<blockquote>test' + IE_BR_STR + '</blockquote>',
+		'<blockquote>test<br /></blockquote>',
 		'Block level'
 	);
 
@@ -124,7 +118,7 @@ QUnit.module('plugins/bbcode - HTML to BBCode', {
 
 QUnit.test('Remove empty', function (assert) {
 	assert.equal(
-		this.htmlToBBCode('<b>' + IE_BR_STR + '</b>'),
+		this.htmlToBBCode('<b><br /></b>'),
 		'',
 		'Empty tag with newline'
 	);
@@ -136,7 +130,7 @@ QUnit.test('Remove empty', function (assert) {
 	);
 
 	assert.equal(
-		this.htmlToBBCode('<b><span>' + IE_BR_STR + '</span></b>'),
+		this.htmlToBBCode('<b><span><br /></span></b>'),
 		'',
 		'Empty tag with only whitespace content'
 	);
@@ -202,7 +196,7 @@ QUnit.test('New line handling', function (assert) {
 	assert.equal(
 		this.htmlToBBCode(
 			'test<div>' +
-				'<strong><em>test' + IE_BR_STR + '</em></strong>' +
+				'<strong><em>test<br /></em></strong>' +
 			'</div>test'
 		),
 		'test\n[b][i]test[/i][/b]\ntest',
@@ -241,7 +235,7 @@ QUnit.test('New line handling', function (assert) {
 		this.htmlToBBCode(
 			'<div>' +
 				'<div>text</div>' +
-				'<div>' + IE_BR_STR + '</div>' +
+				'<div><br /></div>' +
 				'<div>text</div>' +
 			'</div>'
 		),
@@ -252,7 +246,7 @@ QUnit.test('New line handling', function (assert) {
 	assert.equal(
 		this.htmlToBBCode(
 			'<div>text</div>' +
-			'<div>' + IE_BR_STR + '</div>' +
+			'<div><br /></div>' +
 			'<ul><li>text</li></ul>'
 		),
 		'text\n\n[ul]\n[li]text[/li]\n[/ul]\n',
@@ -262,8 +256,8 @@ QUnit.test('New line handling', function (assert) {
 	assert.equal(
 		this.htmlToBBCode(
 			'<div>text</div>' +
-			'<div>' + IE_BR_STR + '</div>' +
-			'<div>' + IE_BR_STR + '</div>' +
+			'<div><br /></div>' +
+			'<div><br /></div>' +
 			'<ul><li>text</li></ul>'
 		),
 		'text\n\n\n[ul]\n[li]text[/li]\n[/ul]\n',
@@ -277,14 +271,14 @@ QUnit.test('New line handling', function (assert) {
 	);
 
 	assert.equal(
-		this.htmlToBBCode('<div>text<br />text' + IE_BR_STR + '</div>'),
+		this.htmlToBBCode('<div>text<br />text<br /></div>'),
 		'text\ntext',
 		'Collapsed end BR tag'
 	);
 
 	assert.equal(
 		this.htmlToBBCode(
-			'<ul><li>newline<br />' + IE_BR_STR + '</li></ul>'
+			'<ul><li>newline<br /><br /></li></ul>'
 		),
 		'[ul]\n[li]newline\n[/li]\n[/ul]\n',
 		'List item last child block level'
@@ -292,7 +286,7 @@ QUnit.test('New line handling', function (assert) {
 
 	assert.equal(
 		this.htmlToBBCode(
-			'<div><code>newline' + IE_BR_STR + '</code></div>' +
+			'<div><code>newline<br /></code></div>' +
 			'<div>newline</div>'
 		),
 		'[code]newline[/code]\nnewline',
@@ -558,26 +552,23 @@ QUnit.test('colour', function (assert) {
 		'Font tag color attribute normal'
 	);
 
-	// Edge 16 doesn't support rgb as color attribute value
-	if (!/Edge/.test(navigator.userAgent)) {
-		assert.equal(
-			this.htmlToBBCode('<font color="rgb(0,0,0)">test</font>'),
-			'[color=#000000]test[/color]',
-			'Font tag color attribute rgb'
-		);
-	}
+	assert.equal(
+		this.htmlToBBCode('<font color="rgb(0,0,0)">test</font>'),
+		'[color=#000000]test[/color]',
+		'Font tag color attribute rgb'
+	);
 });
 
 
 QUnit.test('List', function (assert) {
 	assert.equal(
-		this.htmlToBBCode('<ul><li>test' + IE_BR_STR + '</li></ul>'),
+		this.htmlToBBCode('<ul><li>test<br /></li></ul>'),
 		'[ul]\n[li]test[/li]\n[/ul]\n',
 		'UL tag'
 	);
 
 	assert.equal(
-		this.htmlToBBCode('<ol><li>test' + IE_BR_STR + '</li></ol>'),
+		this.htmlToBBCode('<ol><li>test<br /></li></ol>'),
 		'[ol]\n[li]test[/li]\n[/ol]\n',
 		'OL tag'
 	);
@@ -587,7 +578,7 @@ QUnit.test('List', function (assert) {
 			'<ul>' +
 				'<li>test' +
 					'<ul>' +
-						'<li>sub' + IE_BR_STR + '</li>' +
+						'<li>sub<br /></li>' +
 					'</ul>' +
 				'</li>' +
 			'</ul>'
@@ -784,20 +775,15 @@ QUnit.test('Code', function (assert) {
 
 
 QUnit.test('Left', function (assert) {
-	var isIeOrEdge = browser.ie || 'msImeAlign' in document.body.style;
-
-	// IE will return text-align when a parents direction is changed
-	// so will be skipped in IE unless the direction is different
-	// from the parent alignment
 	assert.equal(
 		this.htmlToBBCode('<div style="text-align: left">test</div>'),
-		isIeOrEdge ? 'test' : '[left]test[/left]\n',
+		'[left]test[/left]\n',
 		'CSS text-align'
 	);
 
 	assert.equal(
 		this.htmlToBBCode('<div align="left">test</div>'),
-		isIeOrEdge ? 'test' : '[left]test[/left]\n',
+		'[left]test[/left]\n',
 		'Align attribute'
 	);
 });

--- a/tests/unit/formats/bbcode.parser.js
+++ b/tests/unit/formats/bbcode.parser.js
@@ -1,11 +1,5 @@
 import * as utils from 'tests/unit/utils.js';
-import * as browser from 'src/lib/browser.js';
 import 'src/formats/bbcode.js';
-
-// In IE < 11 a BR at the end of a block level element
-// causes a line break. In all other browsers it's collapsed.
-var IE_BR_FIX = browser.ie && browser.ie < 11;
-var IE_BR_STR = IE_BR_FIX ? '' : '<br />';
 
 
 QUnit.module('plugins/bbcode#Parser', {
@@ -254,12 +248,12 @@ QUnit.test('Unknown tags', function (assert) {
 QUnit.test('Do not strip start and end spaces', function (assert) {
 	assert.equal(
 		this.parser.toHTML('\n\n[quote]test[/quote]\n\n\n\n'),
-		'<div>' + IE_BR_STR + '</div>\n' +
-		'<div>' + IE_BR_STR + '</div>\n' +
-		'<blockquote>test' + IE_BR_STR + '</blockquote>' +
-		'<div>' + IE_BR_STR + '</div>\n' +
-		'<div>' + IE_BR_STR + '</div>\n' +
-		'<div><br />' + IE_BR_STR + '</div>\n'
+		'<div><br /></div>\n' +
+		'<div><br /></div>\n' +
+		'<blockquote>test<br /></blockquote>' +
+		'<div><br /></div>\n' +
+		'<div><br /></div>\n' +
+		'<div><br /><br /></div>\n'
 	);
 });
 
@@ -269,8 +263,8 @@ QUnit.test('New Line Handling', function (assert) {
 		this.parser.toHTML('[list][*]test\n[*]test2\nline\n[/list]'),
 
 		'<ul>' +
-			'<li>test' + IE_BR_STR + '</li>' +
-			'<li>test2<br />line' + IE_BR_STR + '</li>' +
+			'<li>test<br /></li>' +
+			'<li>test2<br />line<br /></li>' +
 		'</ul>',
 
 		'List with non-closed [*]'
@@ -278,13 +272,13 @@ QUnit.test('New Line Handling', function (assert) {
 
 	assert.htmlEqual(
 		this.parser.toHTML('[code]test\nline\n[/code]'),
-		'<code>test<br />line<br />' + IE_BR_STR + '</code>',
+		'<code>test<br />line<br /><br /></code>',
 		'Code test'
 	);
 
 	assert.htmlEqual(
 		this.parser.toHTML('[quote]test\nline\n[/quote]'),
-		'<blockquote>test<br />line<br />' + IE_BR_STR + '</blockquote>',
+		'<blockquote>test<br />line<br /><br /></blockquote>',
 		'Quote test'
 	);
 
@@ -292,7 +286,7 @@ QUnit.test('New Line Handling', function (assert) {
 		this.parser.toHTML('[quote][center]test[/center][/quote]'),
 
 		'<blockquote>' +
-			'<div align="center">test' + IE_BR_STR + '</div>' +
+			'<div align="center">test<br /></div>' +
 		'</blockquote>',
 
 		'Two block-level elements together'
@@ -737,19 +731,19 @@ QUnit.test('Font colour', function (assert) {
 QUnit.test('List', function (assert) {
 	assert.htmlEqual(
 		this.parser.toHTML('[ul][li]test[/li][/ul]'),
-		'<ul><li>test' + IE_BR_STR + '</li></ul>',
+		'<ul><li>test<br /></li></ul>',
 		'UL'
 	);
 
 	assert.htmlEqual(
 		this.parser.toHTML('[ol][li]test[/li][/ol]'),
-		'<ol><li>test' + IE_BR_STR + '</li></ol>',
+		'<ol><li>test<br /></li></ol>',
 		'OL'
 	);
 
 	assert.htmlEqual(
 		this.parser.toHTML('[ul][li]test[ul][li]sub[/li][/ul][/li][/ul]'),
-		'<ul><li>test<ul><li>sub' + IE_BR_STR + '</li></ul></li></ul>',
+		'<ul><li>test<ul><li>sub<br /></li></ul></li></ul>',
 		'Nested UL'
 	);
 });
@@ -759,8 +753,8 @@ QUnit.test('Table', function (assert) {
 	assert.htmlEqual(
 		this.parser.toHTML('[table][tr][th]test[/th][/tr]' +
 			'[tr][td]data1[/td][/tr][/table]'),
-		'<div><table><tr><th>test' + IE_BR_STR + '</th></tr>' +
-			'<tr><td>data1' + IE_BR_STR + '</td></tr></table></div>\n',
+		'<div><table><tr><th>test<br /></th></tr>' +
+			'<tr><td>data1<br /></td></tr></table></div>\n',
 		'Normal'
 	);
 });
@@ -859,14 +853,13 @@ QUnit.test('Email', function (assert) {
 QUnit.test('Quote', function (assert) {
 	assert.htmlEqual(
 		this.parser.toHTML('[quote]Testing 1.2.3....[/quote]'),
-		'<blockquote>Testing 1.2.3....' + IE_BR_STR + '</blockquote>',
+		'<blockquote>Testing 1.2.3....<br /></blockquote>',
 		'Normal'
 	);
 
 	assert.htmlEqual(
 		this.parser.toHTML('[quote=admin]Testing 1.2.3....[/quote]'),
-		'<blockquote><cite>admin</cite>Testing 1.2.3....' + IE_BR_STR +
-			'</blockquote>',
+		'<blockquote><cite>admin</cite>Testing 1.2.3....<br /></blockquote>',
 		'With author'
 	);
 });
@@ -875,13 +868,13 @@ QUnit.test('Quote', function (assert) {
 QUnit.test('Code', function (assert) {
 	assert.htmlEqual(
 		this.parser.toHTML('[code]Testing 1.2.3....[/code]'),
-		'<code>Testing 1.2.3....' + IE_BR_STR + '</code>',
+		'<code>Testing 1.2.3....<br /></code>',
 		'Normal'
 	);
 
 	assert.htmlEqual(
 		this.parser.toHTML('[code]Testing [b]test[/b][/code]'),
-		'<code>Testing [b]test[/b]' + IE_BR_STR + '</code>',
+		'<code>Testing [b]test[/b]<br /></code>',
 		'Normal'
 	);
 });
@@ -890,7 +883,7 @@ QUnit.test('Code', function (assert) {
 QUnit.test('Left', function (assert) {
 	assert.htmlEqual(
 		this.parser.toHTML('[left]Testing 1.2.3....[/left]'),
-		'<div align="left">Testing 1.2.3....' + IE_BR_STR + '</div>',
+		'<div align="left">Testing 1.2.3....<br /></div>',
 		'Normal'
 	);
 });
@@ -899,7 +892,7 @@ QUnit.test('Left', function (assert) {
 QUnit.test('Right', function (assert) {
 	assert.htmlEqual(
 		this.parser.toHTML('[right]Testing 1.2.3....[/right]'),
-		'<div align="right">Testing 1.2.3....' + IE_BR_STR + '</div>',
+		'<div align="right">Testing 1.2.3....<br /></div>',
 		'Normal'
 	);
 });
@@ -908,7 +901,7 @@ QUnit.test('Right', function (assert) {
 QUnit.test('Centre', function (assert) {
 	assert.htmlEqual(
 		this.parser.toHTML('[center]Testing 1.2.3....[/center]'),
-		'<div align="center">Testing 1.2.3....' + IE_BR_STR + '</div>',
+		'<div align="center">Testing 1.2.3....<br /></div>',
 		'Normal'
 	);
 });
@@ -917,7 +910,7 @@ QUnit.test('Centre', function (assert) {
 QUnit.test('Justify', function (assert) {
 	assert.htmlEqual(
 		this.parser.toHTML('[justify]Testing 1.2.3....[/justify]'),
-		'<div align="justify">Testing 1.2.3....' + IE_BR_STR + '</div>',
+		'<div align="justify">Testing 1.2.3....<br /></div>',
 		'Normal'
 	);
 });
@@ -1140,7 +1133,7 @@ QUnit.test('HTML injection', function (assert) {
 	assert.equal(
 		this.parser.toHTML('[quote=test<b>test</b>test]test[/quote]'),
 		'<blockquote><cite>test&lt;b&gt;test&lt;/b&gt;test</cite>' +
-			'test' + IE_BR_STR + '</blockquote>',
+			'test<br /></blockquote>',
 		'Inject HTML script'
 	);
 });

--- a/tests/unit/formats/xhtml.js
+++ b/tests/unit/formats/xhtml.js
@@ -15,15 +15,7 @@ var moduleSetup = function () {
 	};
 
 	this.filterStripWhiteSpace = function (html) {
-		return utils
-			.stripWhiteSpace(this.filterHtml(html))
-			// IE < 9 outputs styles in upper case
-			.replace(/style="[^"]+"/g, function (match) {
-				return match
-					.toLowerCase()
-					// Make sure the last ; is added to the style attribute
-					.replace(/;?"$/, ';"');
-			});
+		return utils.stripWhiteSpace(this.filterHtml(html));
 	};
 };
 
@@ -961,25 +953,17 @@ QUnit.test('Mozilla\'s junk attributes fix', function (assert) {
 
 
 QUnit.test('Should remove empty nlf tags', function (assert) {
-	var IE_VER = sceditor.ie;
-
-	// In IE < 11 a BR at the end of a block level element
-	// causes a double line break.
-	var IE_BR_FIX = IE_VER && IE_VER < 11;
-
 	assert.htmlEqual(
 		this.filterStripWhiteSpace('<div class="sceditor-nlf"></div>'),
 		'',
 		'Empty'
 	);
 
-	if (!IE_BR_FIX) {
-		assert.htmlEqual(
-			this.filterStripWhiteSpace('<div class="sceditor-nlf"><br /></div>'),
-			'',
-			'Empty with BR'
-		);
-	}
+	assert.htmlEqual(
+		this.filterStripWhiteSpace('<div class="sceditor-nlf"><br /></div>'),
+		'',
+		'Empty with BR'
+	);
 });
 
 QUnit.test('Should remove the nlf class from none empty nlf tags', function (assert) {

--- a/tests/unit/lib/SCEditor.js
+++ b/tests/unit/lib/SCEditor.js
@@ -1,7 +1,6 @@
 import SCEditor from 'src/lib/SCEditor.js';
 import defaultCommands from 'src/lib/defaultCommands.js';
 import defaultOptions from 'src/lib/defaultOptions.js';
-import * as browser from 'src/lib/browser.js';
 import * as utils from 'tests/unit/utils.js';
 import rangy from 'rangy';
 
@@ -130,13 +129,6 @@ QUnit.test('autofocusEnd', function (assert) {
 
 	var expected = '<p>The quick brown fox jumps ' +
 		'over the lazy dog.|<br /></p>';
-
-	// IE treats <br />'s as newlines even at the end of blocks so
-	// if it is a BR, the cursor should be placed after the
-	if (browser.ie && browser.ie < 11) {
-		expected = '<p>The quick brown fox jumps ' +
-		'over the lazy dog.<br />|</p>';
-	}
 
 	assert.nodesEqual(body.firstChild, utils.htmlToNode(expected));
 });

--- a/tests/unit/lib/dom.js
+++ b/tests/unit/lib/dom.js
@@ -1146,11 +1146,10 @@ QUnit.test('getStyle()', function (assert) {
 
 QUnit.test('getStyle() - Normalise text-align', function (assert) {
 	var node = utils.htmlToNode(
-		'<div style="direction: rtl;text-align: right;">test</div>'
+		'<div style="direction: rtl;">test</div>'
 	);
 
-	// If direction is left-to-right and text-align is right,
-	// it shouldn't return anything.
+	// It shouldn't return anything to text-align as isn't set.
 	assert.strictEqual(dom.getStyle(node, 'direction'), 'rtl');
 	assert.strictEqual(dom.getStyle(node, 'textAlign'), '');
 });

--- a/tests/unit/utils.js
+++ b/tests/unit/utils.js
@@ -1,17 +1,7 @@
 export function htmlToDiv(html) {
 	var container = document.createElement('div');
 
-	// IE < 9 strips whitespace from innerHTML.
-	// To fix it wrap the HTML in a <pre> tag so IE keeps the
-	// whitespce intact and then move the children out of the
-	// <pre> tag.
-	container.innerHTML = '<pre>' + html + '</pre>';
-
-	var pre = container.firstChild;
-	while (pre.firstChild) {
-		container.appendChild(pre.firstChild);
-	}
-	container.removeChild(pre);
+	container.innerHTML = html;
 
 	$('#qunit-fixture').append(container);
 


### PR DESCRIPTION
Drop IE and legacy pre-blink Edge support.

This should make it a lot easier to fix bugs / add new featuers as both IE and legacy Edge have a lot of edge cases and require a lot of manual testing. As far as I can tell legacy Edge support is ending in March so should be safe to drop.

Both browser should still work in source mode if `runWithoutWysiwygSupport` is enabled.