### PR TITLE
Unbind updateOriginal() correctly in destroy()

### DIFF
--- a/src/lib/SCEditor.js
+++ b/src/lib/SCEditor.js
@@ -1397,7 +1397,7 @@ export default function SCEditor(original, userOptions) {
 		var form = original.form;
 		if (form) {
 			dom.off(form, 'reset', handleFormReset);
-			dom.off(form, 'submit', base.updateOriginal);
+			dom.off(form, 'submit', base.updateOriginal, dom.EVENT_CAPTURE);
 		}
 
 		dom.remove(sourceEditor);

--- a/tests/unit/lib/SCEditor.js
+++ b/tests/unit/lib/SCEditor.js
@@ -215,6 +215,34 @@ QUnit.test('destroy()', function (assert) {
 	reloadEditor();
 });
 
+QUnit.test('destroy() - Unbind updateOriginal', function (assert) {
+	var textarea = document.createElement('textarea');
+	var submit = document.createElement('input');
+	submit.type = 'submit';
+
+	var form = document.createElement('form');
+	form.addEventListener('submit', function (e) {
+		e.preventDefault();
+	});
+	form.appendChild(submit);
+	form.appendChild(textarea);
+
+	$fixture.append(form);
+
+	var sceditor = new SCEditor(textarea, { format: 'bbcode' });
+	sceditor.val('testing');
+	submit.click();
+
+	assert.equal(textarea.value, 'testing');
+
+	sceditor.val('testing 123');
+	sceditor.destroy();
+	submit.click();
+
+	assert.equal(textarea.value, 'testing');
+	form.parentNode.removeChild(form);
+});
+
 
 QUnit.test('wysiwygEditorInsertHtml()', function (assert) {
 	if (IS_PHANTOMJS) {


### PR DESCRIPTION
Makes destroy() correctly unbind updateOriginal() from form submit event. Fixes #735