### PR TITLE
Prevent copying inherited styles and merge inline styles on paste

### DIFF
--- a/src/lib/SCEditor.js
+++ b/src/lib/SCEditor.js
@@ -1477,11 +1477,14 @@ export default function SCEditor(original, userOptions) {
 
 	/**
 	 * Handles the WYSIWYG editors cut & copy events
+	 *
+	 * By default browsers also copy inherited styling from the stylesheet and
+	 * browser default styling which is unnecessary.
+	 *
+	 * This will ignore inherited styles and only copy inline styling.
 	 * @private
 	 */
 	handleCutCopyEvt = function (e) {
-		// By default browsers also copy the default styling which is
-		// unnecessary, make it only copy the actual styled HTML
 		var range = rangeHelper.selectedRange();
 		if (range) {
 			var container = dom.createElement('div', {}, wysiwygDocument);

--- a/src/lib/SCEditor.js
+++ b/src/lib/SCEditor.js
@@ -1493,7 +1493,7 @@ export default function SCEditor(original, userOptions) {
 			// Copy all inline parent nodes up to the first block parent so can
 			// copy inline styles
 			var parent = range.commonAncestorContainer;
-			while (parent && dom.isInline(parent)) {
+			while (parent && dom.isInline(parent, true)) {
 				if (parent.nodeType === dom.ELEMENT_NODE) {
 					var clone = parent.cloneNode();
 					if (container.firstChild) {

--- a/src/lib/SCEditor.js
+++ b/src/lib/SCEditor.js
@@ -320,6 +320,7 @@ export default function SCEditor(original, userOptions) {
 		initResize,
 		initEmoticons,
 		handlePasteEvt,
+		handleCopyEvt,
 		handlePasteData,
 		handleKeyDown,
 		handleBackSpace,
@@ -663,6 +664,7 @@ export default function SCEditor(original, userOptions) {
 		dom.on(wysiwygBody, 'blur', valueChangedBlur);
 		dom.on(wysiwygBody, 'keyup', valueChangedKeyUp);
 		dom.on(wysiwygBody, 'paste', handlePasteEvt);
+		dom.on(wysiwygBody, 'copy', handleCopyEvt);
 		dom.on(wysiwygBody, compositionEvents, handleComposition);
 		dom.on(wysiwygBody, checkSelectionEvents, checkSelectionChanged);
 		dom.on(wysiwygBody, eventsToForward, handleEvent);
@@ -1471,6 +1473,18 @@ export default function SCEditor(original, userOptions) {
 
 			base.closeDropDown();
 		}
+	};
+
+	/**
+	 * Handles the WYSIWYG editors copy event
+	 * @private
+	 */
+	handleCopyEvt = function (e) {
+		// By default browsers also copy the default styling which is
+		// unnecessary, make it only copy the actual styled HTML
+		e.clipboardData.setData('text/html', rangeHelper.selectedHtml());
+		e.clipboardData.setData('text/plain',
+			rangeHelper.selectedRange().toString());
 	};
 
 	/**

--- a/tests/unit/htmlAssert.js
+++ b/tests/unit/htmlAssert.js
@@ -21,7 +21,8 @@ var normalize = function (parentNode) {
 };
 
 var compareNodes = function (nodeA, nodeB) {
-	if (nodeA.nodeName.toLowerCase() !== nodeB.nodeName.toLowerCase() ||
+	if (nodeA.nodeName && nodeB.nodeName &&
+		nodeA.nodeName.toLowerCase() !== nodeB.nodeName.toLowerCase() ||
 		nodeA.nodeValue !== nodeB.nodeValue ||
 		nodeA.nodeType  !== nodeB.nodeType ||
 		nodeA.className !== nodeB.className) {

--- a/tests/unit/lib/dom.js
+++ b/tests/unit/lib/dom.js
@@ -1214,3 +1214,399 @@ QUnit.test('hasStyle() - No style attribute', function (assert) {
 
 	assert.ok(!dom.hasStyle(node, 'color'));
 });
+
+
+QUnit.test('merge() - parent matching style', function (assert) {
+	var node = utils.htmlToNode(
+		'<div>' +
+			'1' +
+			'<span style="font-weight: bold; font-size: 12px">' +
+				'2' +
+				'<span style="font-weight: bold;">' +
+					'3' +
+				'</span>' +
+				'4' +
+			'</span>' +
+			'5' +
+		'</div>'
+	);
+
+	dom.merge(node);
+
+	assert.nodesEqual(
+		node,
+		utils.htmlToNode(
+			'<div>' +
+				'1' +
+				'<span style="font-weight: bold; font-size: 12px">' +
+					'234' +
+				'</span>' +
+				'5' +
+			'</div>'
+		)
+	);
+});
+
+QUnit.test('merge() - nested parent matching style', function (assert) {
+	var node = utils.htmlToNode(
+		'<div>' +
+			'1' +
+			'<span style="font-weight: bold; font-size: 12px">' +
+				'2' +
+				'<b>' +
+					'<span style="font-size: 12px; font-style: italic">' +
+						'3' +
+					'</span>' +
+				'</b>' +
+				'4' +
+			'</span>' +
+			'5' +
+		'</div>'
+	);
+
+	dom.merge(node);
+
+	assert.nodesEqual(
+		node,
+		utils.htmlToNode(
+			'<div>' +
+				'1' +
+				'<span style="font-weight: bold; font-size: 12px">' +
+					'2' +
+					'<b>' +
+						'<span style="font-style: italic">' +
+							'3' +
+						'</span>' +
+					'</b>' +
+					'4' +
+				'</span>' +
+				'5' +
+			'</div>'
+		)
+	);
+});
+
+QUnit.test('merge() - nested span merge attribute', function (assert) {
+	var node = utils.htmlToNode(
+		'<div>' +
+			'1' +
+			'<span data-sce-test="2">' +
+				'2' +
+				'<span data-sce-test="2">3</span>' +
+				'4' +
+			'</span>' +
+			'5' +
+		'</div>'
+	);
+
+	dom.merge(node);
+
+	assert.nodesEqual(
+		node,
+		utils.htmlToNode(
+			'<div>' +
+				'1' +
+				'<span data-sce-test="2">' +
+					'234' +
+				'</span>' +
+				'5' +
+			'</div>'
+		)
+	);
+});
+
+QUnit.test('merge() - nested span merge multiple attributes', function (assert) {
+	var node = utils.htmlToNode(
+		'<div>' +
+			'1' +
+			'<span data-sce-a="1" data-sce-b="2">' +
+				'2' +
+				'<span data-sce-a="1" data-sce-b="2">3</span>' +
+				'4' +
+			'</span>' +
+			'5' +
+		'</div>'
+	);
+
+	dom.merge(node);
+
+	assert.nodesEqual(
+		node,
+		utils.htmlToNode(
+			'<div>' +
+				'1' +
+				'<span data-sce-a="1" data-sce-b="2">' +
+					'234' +
+				'</span>' +
+				'5' +
+			'</div>'
+		)
+	);
+});
+
+QUnit.test('merge() - nested span attribute different', function (assert) {
+	var node = utils.htmlToNode(
+		'<div>' +
+			'1' +
+			'<span data-sce-test>' +
+				'2' +
+				'<span data-sce-test="2">3</span>' +
+				'4' +
+			'</span>' +
+			'5' +
+		'</div>'
+	);
+
+	dom.merge(node);
+
+	assert.nodesEqual(
+		node,
+		utils.htmlToNode(
+			'<div>' +
+				'1' +
+				'<span data-sce-test>' +
+					'2' +
+					'<span data-sce-test="2">3</span>' +
+					'4' +
+				'</span>' +
+				'5' +
+			'</div>'
+		)
+	);
+});
+
+QUnit.test('merge() - nested span multiple attributes no match', function (assert) {
+	var node = utils.htmlToNode(
+		'<div>' +
+			'1' +
+			'<span data-sce-a="1" data-sce-b="1">' +
+				'2' +
+				'<span data-sce-a="1" data-sce-b="2">3</span>' +
+				'4' +
+			'</span>' +
+			'5' +
+		'</div>'
+	);
+
+	dom.merge(node);
+
+	assert.nodesEqual(
+		node,
+		utils.htmlToNode(
+			'<div>' +
+				'1' +
+				'<span data-sce-a="1" data-sce-b="1">' +
+					'2' +
+					'<span data-sce-a="1" data-sce-b="2">3</span>' +
+					'4' +
+				'</span>' +
+				'5' +
+			'</div>'
+		)
+	);
+});
+
+QUnit.test('merge() - nested strong can merge', function (assert) {
+	var node = utils.htmlToNode(
+		'<div>1<strong>2<strong>3</strong>4</strong>5</div>'
+	);
+
+	dom.merge(node);
+
+	assert.nodesEqual(
+		node,
+		utils.htmlToNode(
+			'<div>1<strong>234</strong>5</div>'
+		)
+	);
+});
+
+QUnit.test('merge() - nested strong cannot merge', function (assert) {
+	var node = utils.htmlToNode(
+		'<div>' +
+			'1' +
+			'<strong>' +
+				'<span style="font-weight: normal;">' +
+					'2<strong>3</strong>4' +
+				'</span>' +
+			'</strong>' +
+			'5' +
+		'</div>'
+	);
+
+	dom.merge(node);
+
+	assert.nodesEqual(
+		node,
+		utils.htmlToNode(
+			'<div>' +
+				'1' +
+				'<strong>' +
+					'<span style="font-weight: normal;">' +
+						'2<strong>3</strong>4' +
+					'</span>' +
+				'</strong>' +
+				'5' +
+			'</div>'
+		)
+	);
+});
+
+QUnit.test('merge() - siblings can merge', function (assert) {
+	var node = utils.htmlToNode(
+		'<div>' +
+			'<span style="font-weight: bold;">' +
+				'1' +
+			'</span>' +
+			'<span style="font-weight: bold;">' +
+				'2' +
+			'</span>' +
+		'</div>'
+	);
+
+	dom.merge(node);
+
+	assert.nodesEqual(
+		node,
+		utils.htmlToNode(
+			'<div>' +
+				'<span style="font-weight: bold;">' +
+					'12' +
+				'</span>' +
+			'</div>'
+		)
+	);
+});
+
+QUnit.test('merge() - siblings can merge mixed style', function (assert) {
+	var node = utils.htmlToNode(
+		'<div>' +
+			'<span style="font-size: 12px; font-weight: bold;">' +
+				'1' +
+			'</span>' +
+			'<span style="font-weight: bold;font-size: 12px;">' +
+				'2' +
+			'</span>' +
+		'</div>'
+	);
+
+	dom.merge(node);
+
+	assert.nodesEqual(
+		node,
+		utils.htmlToNode(
+			'<div>' +
+				'<span style="font-size: 12px; font-weight: bold;">' +
+					'12' +
+				'</span>' +
+			'</div>'
+		)
+	);
+});
+
+QUnit.test('merge() - siblings cannot merge', function (assert) {
+	var node = utils.htmlToNode(
+		'<div>' +
+			'<span style="font-weight: bold;">' +
+				'1' +
+			'</span>' +
+			'<span style="font-weight: 900;">' +
+				'2' +
+			'</span>' +
+		'</div>'
+	);
+
+	dom.merge(node);
+
+	assert.nodesEqual(
+		node,
+		utils.htmlToNode(
+			'<div>' +
+				'<span style="font-weight: bold;">' +
+					'1' +
+				'</span>' +
+				'<span style="font-weight: 900;">' +
+					'2' +
+				'</span>' +
+			'</div>'
+		)
+	);
+});
+
+QUnit.test('merge() - font tags', function (assert) {
+	var node = utils.htmlToNode(
+		'<div style="font-family: arial; color: #ffff00;">' +
+			'1' +
+			'<font face="Arial" color="#ffff00">' +
+				'2' +
+			'</font>' +
+			'3' +
+		'</div>'
+	);
+
+	dom.merge(node);
+
+	assert.nodesEqual(
+		node,
+		utils.htmlToNode(
+			'<div style="font-family: arial; color: #ffff00;">' +
+				'123' +
+			'</div>'
+		)
+	);
+});
+
+QUnit.test('merge() - font tags nested', function (assert) {
+	var node = utils.htmlToNode(
+		'<div style="font-family: arial; color: #ffff00;">' +
+			'1' +
+			'<font face="arial">' +
+				'2' +
+				'<font color="#ffff00">' +
+					'3' +
+				'</font>' +
+				'4' +
+			'</font>' +
+			'5' +
+		'</div>'
+	);
+
+	dom.merge(node);
+
+	assert.nodesEqual(
+		node,
+		utils.htmlToNode(
+			'<div style="font-family: arial; color: #ffff00;">' +
+				'12345' +
+			'</div>'
+		)
+	);
+});
+
+QUnit.test('merge() - deep with siblings', function (assert) {
+	var node = utils.htmlToNode(
+		'<div>' +
+			'<em><em><em>1</em></em></em>' +
+			'<strong>' +
+				'<em><em><em>2</em></em></em>' +
+				'<em><em><em>3</em></em></em>' +
+				'<em><em><strong>4</strong></em></em>' +
+				'<em><em><em>5</em></em></em>' +
+			'</strong>' +
+		'</div>'
+	);
+
+	dom.merge(node);
+
+	assert.nodesEqual(
+		node,
+		utils.htmlToNode(
+			'<div>' +
+				'<em>1</em>' +
+				'<strong>' +
+					'<em>2345</em>' +
+				'</strong>' +
+			'</div>'
+		)
+	);
+});


### PR DESCRIPTION
This limits what's copied by browsers to exclude inherited styling.

To handle pasting say `<b><em>test</em></b>` into `'<em><b>|</b></em>` which would become `<em><b><b><em>test</em></b></b></em>` it merges a limited set of inline styles and tags so the final HTML will be `<em><b>test</b></em>`.

It will merge inline styles from pasted text if they match the parent tags style and also the b, strong, em, span and font tags when pasting if they match a parent of the same type (both attributes and inline styles).

The exception is `<b>` and `<strong>` which are treated as aliases of each other for merging. Not ideal but if the editor ever ended up with both it would cause a bunch of extra bold tags if they aren't treated as aliases.

Would be good to have some testing around the copy and paste APIs but we would need to start using something like [playwright](https://github.com/microsoft/playwright) first to enable it.

Fixes #708, fixes #764