### PR TITLE
Specify base when parsing integers

### DIFF
--- a/src/lib/defaultCommands.js
+++ b/src/lib/defaultCommands.js
@@ -490,11 +490,11 @@ var defaultCmds = {
 					var attrs  = '';
 
 					if (width) {
-						attrs += ' width="' + parseInt(width) + '"';
+						attrs += ' width="' + parseInt(width, 10) + '"';
 					}
 
 					if (height) {
-						attrs += ' height="' + parseInt(height) + '"';
+						attrs += ' height="' + parseInt(height, 10) + '"';
 					}
 
 					attrs += ' src="' + escape.entities(url) + '"';


### PR DESCRIPTION
When using `parseInt` to resolve image width/height, [MDN recommends](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt#description) passing an explicit `base` as the second parameter.