### PR TITLE
fix: Set focus to the editor after state change

### DIFF
--- a/src/lib/SCEditor.js
+++ b/src/lib/SCEditor.js
@@ -1,4 +1,4 @@
-﻿import * as dom from './dom.js';
+import * as dom from './dom.js';
 import * as utils from './utils.js';
 import defaultOptions from './defaultOptions.js';
 import defaultCommands from './defaultCommands.js';
@@ -1344,6 +1344,7 @@ export default function SCEditor(original, userOptions) {
 		}
 
 		autoExpand();
+		base.focus();
 
 		return base;
 	};
@@ -2222,6 +2223,7 @@ export default function SCEditor(original, userOptions) {
 
 		updateToolBar();
 		updateActiveButtons();
+		base.focus();
 	};
 
 	/**


### PR DESCRIPTION
Keyboard shortcuts only apply when thee editor is in focus, so state changes (toggling editor modes, maximizing) should set focus to the editor.

This unexpected behavior was reported at https://github.com/SimpleMachines/SMF2.1/issues/4698