### PR TITLE
Prevent potention prototype pollution

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -64,6 +64,8 @@ export function extend(targetArg, sourceArg) {
 		/* eslint guard-for-in: off */
 		for (var key in source) {
 			var value = source[key];
+			// Protect against prototype pollution
+			var isSpecialKey = key === '__proto__' || key === 'constructor';
 
 			// Skip undefined values to match jQuery and
 			// skip if target to prevent infinite loop
@@ -72,7 +74,7 @@ export function extend(targetArg, sourceArg) {
 					Object.getPrototypeOf(value) === Object.prototype;
 				var isArray = Array.isArray(value);
 
-				if (isDeep && (isObject || isArray)) {
+				if (!isSpecialKey && isDeep && (isObject || isArray)) {
 					target[key] = extend(
 						true,
 						target[key] || (isArray ? [] : {}),

--- a/tests/unit/lib/utils.js
+++ b/tests/unit/lib/utils.js
@@ -79,6 +79,14 @@ QUnit.test('extend() - Deep', function (assert) {
 	});
 });
 
+QUnit.test('extend() - __proto__ pollution', function (assert) {
+	utils.extend(true, {}, JSON.parse('{"__proto__":{"pollution":true}}'));
+	assert.notStrictEqual({}.pollution, true);
+
+	utils.extend(true, {}, JSON.parse('{"constructor":{"prototype":{"pollution":true}}}'));
+	assert.notStrictEqual({}.pollution, true);
+});
+
 QUnit.test('arrayRemove()', function (assert) {
 	var array = [1, 2, 3, 3, 4, 5];
 


### PR DESCRIPTION
Prevents `extend()` from causing prototype pollution.

As far as I can see this shouldn't be an issue at the moment as it's only used internally and only on trusted inputs but worth guarding against just in case `extend()` is ever used for something else in the future.