### PR TITLE
Set ESLint ecmaVersion to version 6

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "ecmaVersion": 5,
+    "ecmaVersion": 6,
     "sourceType": "module"
   },
   "env": {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,11 +49,6 @@ module.exports = (grunt) => {
 
 		// Style checking of JS code using ESLint
 		eslint: {
-			options: {
-				parserOptions: {
-					ecmaVersion: 2015
-				}
-			},
 			source: {
 				src: ['src/**/*.js']
 			},


### PR DESCRIPTION
ESLint `ecmaVersion` version needs to be version 6 for modules support. Also made the Grunt ESLint plugin use the same config as any editors with ESLint support too so should be no differences now.