### PR TITLE
Make drop-down menus smart

### DIFF
--- a/tests/manual/debug/index.html
+++ b/tests/manual/debug/index.html
@@ -2,6 +2,7 @@
 <html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 
 		<title>Debug Test - SCEditor</title>
 


### PR DESCRIPTION
Makes drop-down menus smart.

If they take up more space than is available below the menu item and there is enough space above, they will open upwards. If there isn't enough space to fully open in either direction they will open in whichever direction has the most space and show a scroll bar so they never overflow the viewport.

Fixes #656, fixes #152 & fixes #543