### PR TITLE
Improve fixNesting()

### DIFF
--- a/src/lib/RangeHelper.js
+++ b/src/lib/RangeHelper.js
@@ -1,5 +1,6 @@
 import * as dom from './dom.js';
 import * as escape from './escape.js';
+import * as utils from './utils.js';
 
 
 /**
@@ -198,12 +199,38 @@ export default function RangeHelper(win, d, sanitize) {
 	 * @memberOf RangeHelper.prototype
 	 */
 	base.insertNode = function (node, endNode) {
-		var	input  = _prepareInput(node, endNode),
+		var	first, last,
+			input  = _prepareInput(node, endNode),
 			range  = base.selectedRange(),
-			parent = range.commonAncestorContainer;
+			parent = range.commonAncestorContainer,
+			emptyNodes = [];
 
 		if (!input) {
 			return false;
+		}
+
+		function removeIfEmpty(node) {
+			// Only remove empty node if it wasn't already empty
+			if (node && dom.isEmpty(node) && emptyNodes.indexOf(node) < 0) {
+				dom.remove(node);
+			}
+		}
+
+		if (range.startContainer !== range.endContainer) {
+			// emptyNodes = Array.from(parent.childNodes).filter(dom.isEmpty);
+			// for (var i = 0; i < parent.childNodes.length; i++) {
+			// 	if (dom.isEmpty(parent.childNodes[i])) {
+			// 		emptyNodes.push(parent.childNodes[i]);
+			// 	}
+			// }
+			utils.each(parent.childNodes, function (_, node) {
+				if (dom.isEmpty(node)) {
+					emptyNodes.push(node);
+				}
+			});
+
+			first = input.firstChild;
+			last = input.lastChild;
 		}
 
 		range.deleteContents();
@@ -216,6 +243,15 @@ export default function RangeHelper(win, d, sanitize) {
 			dom.insertBefore(input, parent);
 		} else {
 			range.insertNode(input);
+
+			// If a node was split or its contents deleted, remove any resulting
+			// empty tags. For example:
+			// <p>|test</p><div>test|</div>
+			// When deleteContents could become:
+			// <p></p>|<div></div>
+			// So remove the empty ones
+			removeIfEmpty(first && first.previousSibling);
+			removeIfEmpty(last && last.nextSibling);
 		}
 
 		base.restoreRange();

--- a/src/lib/RangeHelper.js
+++ b/src/lib/RangeHelper.js
@@ -217,12 +217,6 @@ export default function RangeHelper(win, d, sanitize) {
 		}
 
 		if (range.startContainer !== range.endContainer) {
-			// emptyNodes = Array.from(parent.childNodes).filter(dom.isEmpty);
-			// for (var i = 0; i < parent.childNodes.length; i++) {
-			// 	if (dom.isEmpty(parent.childNodes[i])) {
-			// 		emptyNodes.push(parent.childNodes[i]);
-			// 	}
-			// }
 			utils.each(parent.childNodes, function (_, node) {
 				if (dom.isEmpty(node)) {
 					emptyNodes.push(node);

--- a/src/lib/SCEditor.js
+++ b/src/lib/SCEditor.js
@@ -1701,6 +1701,10 @@ export default function SCEditor(original, userOptions) {
 		rangeHelper.saveRange();
 		replaceEmoticons();
 
+		// Fix any invalid nesting, e.g. if a quote or other block is inserted
+		// into a paragraph
+		dom.fixNesting(wysiwygBody);
+
 		// Scroll the editor after the end of the selection
 		marker   = dom.find(wysiwygBody, '#sceditor-end-marker')[0];
 		dom.show(marker);

--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -779,6 +779,14 @@ export function fixNesting(node) {
 		return node;
 	};
 
+	function isEmpty(node) {
+		if (node.lastChild && isEmpty(node.lastChild)) {
+			remove(node.lastChild);
+		}
+
+		return node.nodeType === 3 ? !node.nodeValue : !node.childNodes.length;
+	}
+
 	traverse(node, function (node) {
 		var list = 'ul,ol',
 			isBlock = !isInline(node, true),
@@ -797,8 +805,13 @@ export function fixNesting(node) {
 			// it still has the same styling
 			copyCSS(parent, middle);
 
-			insertBefore(before, parent);
 			insertBefore(middle, parent);
+			if (!isEmpty(before)) {
+				insertBefore(before, middle);
+			}
+			if (isEmpty(parent)) {
+				remove(parent);
+			}
 		}
 
 		// Fix invalid nested lists which should be wrapped in an li tag

--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -757,7 +757,7 @@ export function isInline(elm, includeCodeAsBlock) {
  * @param {HTMLElement} to
  */
 export function copyCSS(from, to) {
-	if (to.style && from.style) {
+	if (to.style && from.style && from.style.cssText) {
 		to.style.cssText = from.style.cssText + to.style.cssText;
 	}
 }
@@ -781,13 +781,17 @@ export function fixNesting(node) {
 
 	traverse(node, function (node) {
 		var list = 'ul,ol',
-			isBlock = !isInline(node, true);
+			isBlock = !isInline(node, true),
+			isParentInline = isInline(node.parentNode, true);
 
 		// Any blocklevel element inside an inline element needs fixing.
-		if (isBlock && isInline(node.parentNode, true)) {
-			var	parent = getLastInlineParent(node),
-				before = extractContents(parent, node),
-				middle = node;
+		// Also fix <p> tags that contain blocks
+		if (isBlock && (isParentInline || node.parentNode.tagName === 'P')) {
+			var	parent = getLastInlineParent(
+				isParentInline ? node : node.parentNode
+			);
+			var before = extractContents(parent, node);
+			var middle = node;
 
 			// copy current styling so when moved out of the parent
 			// it still has the same styling

--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -777,7 +777,8 @@ export function fixNesting(node) {
 			remove(node.lastChild);
 		}
 
-		return node.nodeType === 3 ? !node.nodeValue : !node.childNodes.length;
+		return node.nodeType === 3 ? !node.nodeValue :
+			(canHaveChildren(node) && !node.childNodes.length);
 	}
 
 	traverse(node, function (node) {

--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -764,6 +764,21 @@ export function copyCSS(from, to) {
 }
 
 /**
+ * Checks if a DOM node is empty
+ *
+ * @param {Node} node
+ * @returns {boolean}
+ */
+export function isEmpty(node) {
+	if (node.lastChild && isEmpty(node.lastChild)) {
+		remove(node.lastChild);
+	}
+
+	return node.nodeType === 3 ? !node.nodeValue :
+		(canHaveChildren(node) && !node.childNodes.length);
+}
+
+/**
  * Fixes block level elements inside in inline elements.
  *
  * Also fixes invalid list nesting by placing nested lists
@@ -772,15 +787,6 @@ export function copyCSS(from, to) {
  * @param {HTMLElement} node
  */
 export function fixNesting(node) {
-	function isEmpty(node) {
-		if (node.lastChild && isEmpty(node.lastChild)) {
-			remove(node.lastChild);
-		}
-
-		return node.nodeType === 3 ? !node.nodeValue :
-			(canHaveChildren(node) && !node.childNodes.length);
-	}
-
 	traverse(node, function (node) {
 		var list = 'ul,ol',
 			isBlock = !isInline(node, true) && node.nodeType !== COMMENT_NODE,

--- a/tests/unit/lib/RangeHelper.js
+++ b/tests/unit/lib/RangeHelper.js
@@ -154,6 +154,56 @@ QUnit.test('insertNode() - Before and after', function (assert) {
 	));
 });
 
+QUnit.test('insertNode() - Remove created empty tags', function (assert) {
+	var range = rangy.createRangyRange();
+	var sel   = rangy.getSelection();
+
+	editableDiv.innerHTML = '<p>text</p><p>text</p>';
+
+	var p1 = editableDiv.firstChild;
+	var p2 = editableDiv.lastChild;
+	range.setStart(p1.firstChild, 0);
+	range.setEnd(p2.firstChild, 4);
+
+	sel.setSingleRange(range);
+
+	rangeHelper.insertNode(utils.htmlToFragment('<b>foo</b>'));
+
+	assert.nodesEqual(editableDiv.firstChild, utils.htmlToNode(
+		'<b>foo</b>'
+	));
+});
+
+QUnit.test('insertNode() - Do not remove existing empty tags', function (assert) {
+	var range = rangy.createRangyRange();
+	var sel   = rangy.getSelection();
+
+	editableDiv.innerHTML = '<p></p>test<p></p>';
+
+	range.setStart(editableDiv, 1);
+	range.setEnd(editableDiv, 2);
+	sel.setSingleRange(range);
+
+	rangeHelper.insertNode(utils.htmlToFragment('<b>foo</b>'));
+
+	assert.htmlEqual(editableDiv.innerHTML, '<p></p><b>foo</b><p></p>');
+});
+
+QUnit.test('insertNode() - Do not remove existing empty tags', function (assert) {
+	var range = rangy.createRangyRange();
+	var sel   = rangy.getSelection();
+
+	editableDiv.innerHTML = '<p></p>test<p></p><p></p>';
+
+	range.setStart(editableDiv, 1);
+	range.setEnd(editableDiv.lastChild, 0);
+	sel.setSingleRange(range);
+
+	rangeHelper.insertNode(utils.htmlToFragment('<b>foo</b>'));
+
+	assert.htmlEqual(editableDiv.innerHTML, '<p></p><b>foo</b><p></p>');
+});
+
 
 QUnit.test('hasSelection() - With selection', function (assert) {
 	var range = rangy.createRangyRange();

--- a/tests/unit/lib/dom.js
+++ b/tests/unit/lib/dom.js
@@ -642,6 +642,28 @@ QUnit.test('fixNesting() - With styling', function (assert) {
 	);
 });
 
+QUnit.test('fixNesting() - Paragraph with blockquote', function (assert) {
+	var quote = document.createElement('blockquote');
+	quote.appendChild(document.createTextNode('1'));
+
+	var p = document.createElement('p');
+	p.appendChild(document.createTextNode('1'));
+	p.appendChild(quote);
+	p.appendChild(document.createTextNode('3'));
+
+	var root = document.createElement('div');
+	root.appendChild(p);
+
+	dom.fixNesting(root);
+
+	assert.nodesEqual(
+		root,
+		utils.htmlToDiv(
+			'<p>1</p><blockquote>1</blockquote><p>3</p>'
+		)
+	);
+});
+
 QUnit.test('fixNesting() - Deeply nested', function (assert) {
 	var node = utils.htmlToDiv(
 		'<span>' +

--- a/tests/unit/lib/dom.js
+++ b/tests/unit/lib/dom.js
@@ -644,7 +644,7 @@ QUnit.test('fixNesting() - With styling', function (assert) {
 
 QUnit.test('fixNesting() - Paragraph with blockquote', function (assert) {
 	var quote = document.createElement('blockquote');
-	quote.appendChild(document.createTextNode('1'));
+	quote.appendChild(document.createTextNode('2'));
 
 	var p = document.createElement('p');
 	p.appendChild(document.createTextNode('1'));
@@ -659,7 +659,37 @@ QUnit.test('fixNesting() - Paragraph with blockquote', function (assert) {
 	assert.nodesEqual(
 		root,
 		utils.htmlToDiv(
-			'<p>1</p><blockquote>1</blockquote><p>3</p>'
+			'<p>1</p><blockquote>2</blockquote><p>3</p>'
+		)
+	);
+});
+
+QUnit.test('fixNesting() - Do not create empty nodes', function (assert) {
+	var node = utils.htmlToDiv(
+		'<span><blockquote>test</blockquote></span>'
+	);
+
+	dom.fixNesting(node);
+
+	assert.nodesEqual(
+		node,
+		utils.htmlToDiv(
+			'<blockquote>test</blockquote>'
+		)
+	);
+});
+
+QUnit.test('fixNesting() - Do not create empty nodes when deeply nested', function (assert) {
+	var node = utils.htmlToDiv(
+		'<em><span><strong><blockquote>test</blockquote></strong></span></em>'
+	);
+
+	dom.fixNesting(node);
+
+	assert.nodesEqual(
+		node,
+		utils.htmlToDiv(
+			'<blockquote>test</blockquote>'
 		)
 	);
 });

--- a/tests/unit/lib/dom.js
+++ b/tests/unit/lib/dom.js
@@ -632,8 +632,10 @@ QUnit.test('fixNesting() - With styling', function (assert) {
 			'<span style="font-weight: bold;">' +
 				'span' +
 			'</span>' +
-			'<div style="font-weight: bold;">' +
-				'div' +
+			'<div>' +
+				'<span style="font-weight: bold;">' +
+					'div' +
+				'</span>' +
 			'</div>' +
 			'<span style="font-weight: bold;">' +
 				'span' +
@@ -674,7 +676,7 @@ QUnit.test('fixNesting() - Do not create empty nodes', function (assert) {
 	assert.nodesEqual(
 		node,
 		utils.htmlToDiv(
-			'<blockquote>test</blockquote>'
+			'<blockquote><span>test</span></blockquote>'
 		)
 	);
 });
@@ -689,7 +691,109 @@ QUnit.test('fixNesting() - Do not create empty nodes when deeply nested', functi
 	assert.nodesEqual(
 		node,
 		utils.htmlToDiv(
-			'<blockquote>test</blockquote>'
+			'<blockquote><em><span><strong>test</strong></span></em></blockquote>'
+		)
+	);
+});
+
+QUnit.test('fixNesting() - Do not create empty nodes when inline styling nested', function (assert) {
+	var node = utils.htmlToDiv(
+		'<em><div><strong><blockquote>4</blockquote></strong></div></em>'
+	);
+
+	dom.fixNesting(node);
+
+	assert.nodesEqual(
+		node,
+		utils.htmlToDiv(
+			'<div><blockquote><em><strong>4</strong></em></blockquote></div>'
+		)
+	);
+});
+
+QUnit.test('fixNesting() - Preserve inline styling', function (assert) {
+	// Below is the following HTML (have to do it manually due to <p> being
+	// closed by the <blockquote> when using innerHTML):
+	//  <p>1</p><strong><p>2</p><p><blockquote>3</blockquote>4</p></strong><p>5</p>
+	var p1 = document.createElement('p');
+	p1.appendChild(document.createTextNode('1'));
+
+	var p2 = document.createElement('p');
+	p2.appendChild(document.createTextNode('2'));
+
+	var quote = document.createElement('blockquote');
+	quote.appendChild(document.createTextNode('3'));
+
+	var p3 = document.createElement('p');
+	p3.appendChild(quote);
+	p3.appendChild(document.createTextNode('4'));
+
+	var strong = document.createElement('strong');
+	strong.appendChild(p2);
+	strong.appendChild(p3);
+
+	var p5 = document.createElement('p');
+	p5.appendChild(document.createTextNode('5'));
+
+	var node = document.createElement('div');
+	node.appendChild(p1);
+	node.appendChild(strong);
+	node.appendChild(p5);
+
+	dom.fixNesting(node);
+
+	assert.nodesEqual(
+		node,
+		utils.htmlToDiv(
+			'<p>1</p>' +
+			'<p><strong>2</strong></p>' +
+			'<blockquote><strong>3</strong></blockquote>' +
+			'<p><strong>4</strong></p>' +
+			'<p>5</p>'
+		)
+	);
+});
+
+QUnit.test('fixNesting() - Preserve inline styling', function (assert) {
+	var node = utils.htmlToDiv(
+		'<em><span><strong>1<blockquote><p>2</p></blockquote>3</strong></span></em>'
+	);
+
+	dom.fixNesting(node);
+
+	assert.nodesEqual(
+		node,
+		utils.htmlToDiv(
+			'<em><span><strong>1</strong></span></em>' +
+			'<blockquote><p><em><span><strong>2</strong></span></em></p></blockquote>' +
+			'<em><span><strong>3</strong></span></em>'
+		)
+	);
+});
+
+QUnit.test('fixNesting() - Preserve inline styling nested', function (assert) {
+	var node = utils.htmlToDiv(
+		'<em>1<div>2<strong>3<blockquote>4</blockquote>5</strong>6</div>7</em>'
+	);
+
+	dom.fixNesting(node);
+
+	assert.nodesEqual(
+		node,
+		utils.htmlToDiv(
+			'<em>1</em>' +
+			'<div>' +
+				'<em>' +
+					'2' +
+					'<strong>3</strong>' +
+				'</em>' +
+				'<blockquote><em><strong>4</strong></em></blockquote>' +
+				'<em>' +
+					'<strong>5</strong>' +
+					'6' +
+				'</em>' +
+			'</div>' +
+			'<em>7</em>'
 		)
 	);
 });
@@ -721,7 +825,11 @@ QUnit.test('fixNesting() - Deeply nested', function (assert) {
 				'</span>' +
 			'</span>' +
 			'<div style="font-weight: bold;">' +
-				'div' +
+				'<span>' +
+					'<span>' +
+						'div' +
+					'</span>' +
+				'</span>' +
 			'</div>' +
 			'<span>' +
 				'<span>' +
@@ -829,11 +937,7 @@ QUnit.test('fixNesting() - With comments', function (assert) {
 		utils.htmlToDiv(
 			'<p>' +
 				'<strong>' +
-					'a' +
-				'</strong>' +
-				'<!-- test -->' +
-				'<strong>' +
-					'b' +
+					'a<!-- test -->b' +
 				'</strong>' +
 			'</p>'
 		)

--- a/tests/unit/lib/dom.js
+++ b/tests/unit/lib/dom.js
@@ -680,6 +680,20 @@ QUnit.test('fixNesting() - Do not create empty nodes', function (assert) {
 		)
 	);
 });
+QUnit.test('fixNesting() - Create nodes with a child that cannot have children', function (assert) {
+	var node = utils.htmlToDiv(
+		'<span><blockquote>test</blockquote><br></span>'
+	);
+
+	dom.fixNesting(node);
+
+	assert.nodesEqual(
+		node,
+		utils.htmlToDiv(
+			'<blockquote><span>test</span></blockquote><span><br /></span>'
+		)
+	);
+});
 
 QUnit.test('fixNesting() - Do not create empty nodes when deeply nested', function (assert) {
 	var node = utils.htmlToDiv(


### PR DESCRIPTION
Updates `fixNesting()` to correctly fix nesting for `<p>` tags containing block elements. Fixes #815, fixes #545 and fixes #768

Changes the behaviour of `fixNesting()` to not split inline elements containing comments.

Also prevents fixNesting() from creating empty tags and copies inline styling when fixing nesting, both of which make more sense and should result in a better UX when editing.

Deprecates the `copyCSS()` function as no longer needed by `fixNesting()`. Should probably also deprecate `findCommonAncestor()` as that's no longer needed and can be removed at some point too.