### PR TITLE
 Add ability to match all attrs in a given tag 

### DIFF
--- a/tests/unit/formats/bbcode.parser.js
+++ b/tests/unit/formats/bbcode.parser.js
@@ -161,6 +161,11 @@ QUnit.test('BBCode closed outside block - No children fix', function (assert) {
 		'[quote][b]something[/b][/quote]\n[b][b]something[/b][/b]',
 		'Quote with tag closed outside'
 	);
+
+	// Put it back the way you found it
+	this.parser = new sceditor.BBCodeParser({
+		fixInvalidChildren: true
+	});
 });
 
 

--- a/tests/unit/formats/bbcode/matching.js
+++ b/tests/unit/formats/bbcode/matching.js
@@ -1,0 +1,117 @@
+import defaultOptions from 'src/lib/defaultOptions.js';
+import 'src/formats/bbcode.js';
+
+QUnit.module('plugins/bbcode - Matching');
+
+sceditor.formats.bbcode.set(
+	'thisoldbbcode', {
+		tags: {
+			abbr: {
+				title: ['test'],
+				test: null
+			}
+		},
+		matchAttrs: sceditor.BBCodeParser.MatchingMode.all,
+		format: function (element, content) {
+			return '[abbr=' + element.getAttribute('title') + ']' + content + '[/abbr]';
+		},
+		html: '<abbr title="{defaultattr}">{0}</abbr>'
+	}
+);
+sceditor.formats.bbcode.set(
+	'springchicken', {
+		tags: {
+			bird: {
+				type: ['duck'],
+				test: null
+			}
+		},
+		matchAttrs: sceditor.BBCodeParser.MatchingMode.any,
+		format: function (element, content) {
+			return '[bird=' + element.getAttribute('type') + ']' + content + '[/bird]';
+		},
+		html: '<bird type="{defaultattr}">{0}</bird>'
+	}
+);
+sceditor.formats.bbcode.set(
+	'insertnamehere', {
+		tags: {
+			species: {
+				classification: ['mammal'],
+				test: null
+			}
+		},
+		format: function (element, content) {
+			return '[species=' + element.getAttribute('classification') + ']' + content + '[/species]';
+		},
+		html: '<species classification="{defaultattr}">{0}</species>'
+	}
+);
+sceditor.formats.bbcode.set('margin', {
+	tags: {
+		'p': null
+	},
+	styles: {
+		'margin': null
+	},
+	format: function (element, content) {
+		return '[margin=' + element.style.margin + ']' +
+			content + '[/margin]';
+	},
+	html: '<p style="margin:{defaultattr}">{0}</p>'
+});
+var
+	mockEditor = {
+		opts: defaultOptions
+	},
+	format = new sceditor.formats.bbcode;
+format.init.call(mockEditor);
+
+QUnit.test('match all attrs', assert => {
+	assert.equal(
+		mockEditor.toBBCode(
+			'<abbr title="attrs.defaultattr" test="value">content</abbr>'
+		),
+		'content'
+	);
+	assert.equal(
+		mockEditor.toBBCode('<abbr title="test" test="value">content</abbr>'),
+		'[abbr=test]content[/abbr]'
+	);
+});
+QUnit.test('match any attr', assert => {
+	assert.equal(
+		mockEditor.toBBCode(
+			'<bird type="attrs.defaultattr" test="value">content</bird>'
+		),
+		'[bird=attrs.defaultattr]content[/bird]'
+	);
+	assert.equal(
+		mockEditor.toBBCode('<bird type="duck" test="value">content</bird>'),
+		'[bird=duck]content[/bird]'
+	);
+});
+QUnit.test('match not specified', assert => {
+	assert.equal(
+		mockEditor.toBBCode(
+			'<species classification="attrs.defaultattr" test="value">content</species>'
+		),
+		'[species=attrs.defaultattr]content[/species]'
+	);
+	assert.equal(
+		mockEditor.toBBCode('<species classification="mammal" test="value">content</species>'),
+		'[species=mammal]content[/species]'
+	);
+});
+QUnit.test('unexpected double match', assert => {
+	assert.equal(
+		mockEditor.toBBCode('<p style="margin: 1em;">content</p>'),
+		'[margin=1em][margin=1em]content[/margin][/margin]'
+	);
+});
+
+// Remember to clean up!
+sceditor.formats.bbcode.remove('thisoldbbcode');
+sceditor.formats.bbcode.remove('springchicken');
+sceditor.formats.bbcode.remove('insertnamehere');
+sceditor.formats.bbcode.remove('margin');

--- a/tests/unit/formats/bbcode/nesting.js
+++ b/tests/unit/formats/bbcode/nesting.js
@@ -1,0 +1,70 @@
+import defaultOptions from 'src/lib/defaultOptions.js';
+import 'src/formats/bbcode.js';
+
+QUnit.module('plugins/bbcode - Nesting');
+
+sceditor.formats.bbcode.set(
+	'thisblockstyle', {
+		styles: {
+			border: null
+		},
+		isInline: false,
+		format: '[block]{0}[/block]',
+		html: '<block>{0}</block>'
+	}
+);
+sceditor.formats.bbcode.set(
+	'thisinlinestyle', {
+		styles: {
+			opacity: null
+		},
+		format: '[inline]{0}[/inline]',
+		html: '<inline>{0}</inline>'
+	}
+);
+sceditor.formats.bbcode.set(
+	'thisblockbbcode', {
+		tags: {
+			block: {
+				test: null
+			}
+		},
+		isInline: false,
+		format: '[block]{0}[/block]',
+		html: '<block>{0}</block>'
+	}
+);
+sceditor.formats.bbcode.set(
+	'thisinlinebbcode', {
+		tags: {
+			block: {
+				testing: null
+			}
+		},
+		format: '[inline]{0}[/inline]',
+		html: '<inline>{0}</inline>'
+	}
+);
+
+var
+	mockEditor = {
+		opts: defaultOptions
+	},
+	format = new sceditor.formats.bbcode;
+format.init.call(mockEditor);
+
+QUnit.test('inline bbcodes must be inside block ones', assert => {
+	assert.equal(
+		mockEditor.toBBCode('<theme style=opacity:1;border:none;"></theme>'),
+		'[block][inline][/inline][/block]'
+	);
+	assert.equal(
+		mockEditor.toBBCode('<block test="yhm" testing="lol"></block>'),
+		'[block][inline][/inline][/block]'
+	);
+});
+
+sceditor.formats.bbcode.remove('thisblockstyle');
+sceditor.formats.bbcode.remove('thisinlinestyle');
+sceditor.formats.bbcode.remove('thisblockbbcode');
+sceditor.formats.bbcode.remove('thisinlinebbcode');

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -10,5 +10,7 @@ import 'tests/unit/lib/escape.js';
 import 'tests/unit/lib/utils.js';
 import 'tests/unit/formats/bbcode.js';
 import 'tests/unit/formats/bbcode.parser.js';
+import 'tests/unit/formats/bbcode/matching.js';
+import 'tests/unit/formats/bbcode/nesting.js';
 import 'tests/unit/formats/xhtml.js';
 import 'tests/unit/jquery.sceditor.js';


### PR DESCRIPTION
This is my set of changes to add an additional mode for matching attributes on HTML tags—require all to match. The default is to match any.

Fix #809

New option added `instance.opts.parserOptions.matchAttrs`
New enumerable added: `sceditor.BBCodeParser.MatchingMode`

The enum has two values:

- `sceditor.BBCodeParser.MatchingMode.all`
- `sceditor.BBCodeParser.MatchingMode.any`—this is the value which will be used if left blank, ie, not set. This way, any existing code will still work exactly as before.

Each individual format option will have the opportunity to specify its own `matchAttrs` and override the global option.