### PR TITLE
initialize plugins before the formatters

### DIFF
--- a/src/lib/SCEditor.js
+++ b/src/lib/SCEditor.js
@@ -312,7 +312,6 @@ export default function SCEditor(original, userOptions) {
 		replaceEmoticons,
 		handleCommand,
 		initEditor,
-		initPlugins,
 		initLocale,
 		initToolBar,
 		initOptions,
@@ -449,12 +448,21 @@ export default function SCEditor(original, userOptions) {
 
 		var FormatCtor = SCEditor.formats[options.format];
 		format = FormatCtor ? new FormatCtor() : {};
+		/*
+		 * Plugins should be initialized before the formatters since
+		 * they may wish to add or change formatting handlers and
+		 * since the bbcode format caches its handlers,
+		 * such changes must be done first.
+		 */
+		pluginManager = new PluginManager(base);
+		(options.plugins || '').split(',').forEach(function (plugin) {
+			pluginManager.register(plugin.trim());
+		});
 		if ('init' in format) {
 			format.init.call(base);
 		}
 
 		// create the editor
-		initPlugins();
 		initEmoticons();
 		initToolBar();
 		initEditor();
@@ -490,17 +498,6 @@ export default function SCEditor(original, userOptions) {
 		}
 	};
 
-	initPlugins = function () {
-		var plugins   = options.plugins;
-
-		plugins       = plugins ? plugins.toString().split(',') : [];
-		pluginManager = new PluginManager(base);
-
-		plugins.forEach(function (plugin) {
-			pluginManager.register(plugin.trim());
-		});
-	};
-
 	/**
 	 * Init the locale variable with the specified locale if possible
 	 * @private
@@ -533,7 +530,8 @@ export default function SCEditor(original, userOptions) {
 			allowfullscreen: true
 		});
 
-		/* This needs to be done right after they are created because,
+		/*
+		 * This needs to be done right after they are created because,
 		 * for any reason, the user may not want the value to be tinkered
 		 * by any filters.
 		 */


### PR DESCRIPTION
Plugins should be initialized before the formatters since they may wish to add or change formatting handlers and since the bbcode format caches its handlers, such changes must be done first.

One possible caveat is that the public API `sceditor.command` won't work as intended in plugin init—#686 works around this by duplicating some code

		base.commands = utils
			.extend(true, {}, (userOptions.commands || defaultCommands));

That workaround seems kinda ugly to me, and will probably cause some undesired conflicts when running multiple editor instances on the same page. I haven't tested that, though.

Come to think of it, `sceditor.formats.bbcode` may also exhibit the same behavior due to what looks like shared memory access. I have not tested this either.

I see more of what could lead to surprising results: methods that get pointers to iframe related objects return null, range helper also is null, but those can easily be worked around by waiting for the ready signal.