### PR TITLE
Add missing blocks to blockLevelList

### DIFF
--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -699,7 +699,9 @@ export function convertElement(element, toTagName) {
  * @type {string}
  */
 export var blockLevelList = '|body|hr|p|div|h1|h2|h3|h4|h5|h6|address|pre|' +
-	'form|table|tbody|thead|tfoot|th|tr|td|li|ol|ul|blockquote|center|';
+	'form|table|tbody|thead|tfoot|th|tr|td|li|ol|ul|blockquote|center|' +
+	'details|section|article|aside|nav|main|header|hgroup|footer|fieldset|' +
+	'dl|dt|dd|figure|figcaption|';
 
 /**
  * List of elements that do not allow children separated by bars (|)

--- a/tests/unit/lib/dom.js
+++ b/tests/unit/lib/dom.js
@@ -788,6 +788,47 @@ QUnit.test('fixNesting() - With comments', function (assert) {
 	);
 });
 
+QUnit.test('fixNesting() - <details> block', function (assert) {
+	var node = utils.htmlToDiv(
+		'<details>' +
+			'<summary>test</summary>' +
+			'<div>test</div>' +
+		'</details>'
+	);
+
+	dom.fixNesting(node);
+
+	assert.nodesEqual(
+		node,
+		utils.htmlToDiv(
+			'<details>' +
+				'<summary>test</summary>' +
+				'<div>test</div>' +
+			'</details>'
+		)
+	);
+});
+
+QUnit.test('fixNesting() - <section/article/aside> block', function (assert) {
+	var node = utils.htmlToDiv(
+		'<section><article><aside>' +
+			'<div>test</div>' +
+		'</aside></section></section>'
+	);
+
+	dom.fixNesting(node);
+
+	assert.nodesEqual(
+		node,
+		utils.htmlToDiv(
+			'<section><article><aside>' +
+				'<div>test</div>' +
+			'</aside></section></section>'
+		)
+	);
+});
+
+
 QUnit.test('removeWhiteSpace() - Preserve line breaks', function (assert) {
 	var node = utils.htmlToDiv(
 		'<div style="white-space: pre-line">    ' +


### PR DESCRIPTION
Adds missing block elements to `blockLevelList` so `fixNesting()` handles them correctly.