### PR TITLE
Prevent collapsed white space text nodes being wrapped

### DIFF
--- a/src/lib/SCEditor.js
+++ b/src/lib/SCEditor.js
@@ -27,12 +27,17 @@ function wrapInlines(body, doc) {
 
 	dom.traverse(body, function (node) {
 		if (dom.isInline(node, true)) {
-			if (!wrapper) {
-				wrapper = dom.createElement('p', {}, doc);
-				dom.insertBefore(wrapper, node);
-			}
+			// Ignore text nodes unless they contain non-whitespace chars as
+			// whitespace will be collapsed.
+			// Ignore sceditor-ignore elements unless wrapping siblings
+			// Should still wrap both if wrapping siblings.
+			if (wrapper || node.nodeType === dom.TEXT_NODE ?
+				/\S/.test(node.nodeValue) : !dom.is(node, '.sceditor-ignore')) {
+				if (!wrapper) {
+					wrapper = dom.createElement('p', {}, doc);
+					dom.insertBefore(wrapper, node);
+				}
 
-			if (node.nodeType !== dom.TEXT_NODE || node.nodeValue !== '') {
 				dom.appendChild(wrapper, node);
 			}
 		} else {

--- a/tests/unit/lib/SCEditor.js
+++ b/tests/unit/lib/SCEditor.js
@@ -574,3 +574,28 @@ QUnit.test('Allow target=blank links', function (assert) {
 		'<img src=\"removed.jpg\" />\n' +
 	'</p>');
 });
+
+
+QUnit.test('Do not wrap whitespace text nodes', function (assert) {
+	var body = sceditor.getBody();
+	var rangeHelper = sceditor.getRangeHelper();
+	var testHtml = '<p>test</p>     ';
+
+	sceditor.focus();
+
+	body.innerHTML = testHtml;
+
+	var range = rangeHelper.cloneSelected();
+	range.setStartAfter(body.firstChild.firstChild);
+	range.collapse(true);
+	rangeHelper.selectRange(range);
+	body.dispatchEvent(new Event('selectionchange'));
+
+	var range = rangeHelper.cloneSelected();
+	range.setStart(body.lastChild, 1);
+	range.collapse(true);
+	rangeHelper.selectRange(range);
+	body.dispatchEvent(new Event('selectionchange'));
+
+	assert.htmlEqual(body.innerHTML, testHtml);
+});


### PR DESCRIPTION
Should only wrap collapsed white space text nodes when wrapping other nodes.

Prevents extra newlines from being inserted from collapsed white space being wrapped.