### PR TITLE
Focus editor after maximising / switching mode

### DIFF
--- a/src/lib/defaultCommands.js
+++ b/src/lib/defaultCommands.js
@@ -922,9 +922,11 @@ var defaultCmds = {
 		},
 		exec: function () {
 			this.maximize(!this.maximize());
+			this.focus();
 		},
 		txtExec: function () {
 			this.maximize(!this.maximize());
+			this.focus();
 		},
 		tooltip: 'Maximize',
 		shortcut: 'Ctrl+Shift+M'
@@ -938,9 +940,11 @@ var defaultCmds = {
 		},
 		exec: function () {
 			this.toggleSourceMode();
+			this.focus();
 		},
 		txtExec: function () {
 			this.toggleSourceMode();
+			this.focus();
 		},
 		tooltip: 'View source',
 		shortcut: 'Ctrl+Shift+S'


### PR DESCRIPTION
Alternative fix to focus issue fixed by #806. This should be safe as only changes the behaviour of the `maximize` and `source` commands.