### PR TITLE
youtube shortcode support

### DIFF
--- a/src/lib/defaultCommands.js
+++ b/src/lib/defaultCommands.js
@@ -745,7 +745,7 @@ var defaultCmds = {
 
 			dom.on(content, 'click', '.button', function (e) {
 				var val = dom.find(content, '#link')[0].value;
-				var idMatch = val.match(/(?:v=|v\/|embed\/|youtu.be\/)(.{11})/);
+				var idMatch = val.match(/(?:v=|v\/|embed\/|youtu.be\/)?([a-zA-Z0-9_-]{11})/);
 				var timeMatch = val.match(/[&|?](?:star)?t=((\d+[hms]?){1,3})/);
 				var time = 0;
 


### PR DESCRIPTION
The dropdown menu for youtube only supports full youtube URL. It does nothing if the youtube ID/shortcode is pasted into the box. This PR fixes that issue.