### PR TITLE
Update PR #821

### DIFF
--- a/tests/unit/formats/bbcode.js
+++ b/tests/unit/formats/bbcode.js
@@ -840,3 +840,32 @@ QUnit.test('YouTube', function (assert) {
 		'[youtube]xyz[/youtube]'
 	);
 });
+
+
+QUnit.test('Allow changing BBCode properties after creation', function (assert) {
+	// This is for backwards compatibility and will change in the next breaking
+	// release
+
+	this.parser = new $.sceditor.BBCodeParser({
+		quoteType: function (str) {
+			return '\'' +
+				str.replace(/\\/g, '\\\\').replace(/'/g, '\\\'') +
+				'\'';
+		}
+	});
+
+	var oldFormat = sceditor.formats.bbcode.get('quote').format;
+	sceditor.formats.bbcode.set('quote', {
+		format: 'new format'
+	});
+
+	assert.equal(
+		this.htmlToBBCode('<blockquote>Testing 1.2.3....</blockquote>'),
+		'new format'
+	);
+
+	// Reset [quote]'s default format
+	sceditor.formats.bbcode.set('quote', {
+		format: oldFormat
+	});
+});

--- a/tests/unit/formats/bbcode/matching.js
+++ b/tests/unit/formats/bbcode/matching.js
@@ -1,117 +1,121 @@
 import defaultOptions from 'src/lib/defaultOptions.js';
 import 'src/formats/bbcode.js';
 
-QUnit.module('plugins/bbcode - Matching');
-
-sceditor.formats.bbcode.set(
-	'thisoldbbcode', {
-		tags: {
-			abbr: {
-				title: ['test'],
-				test: null
+QUnit.module('plugins/bbcode - Matching', {
+	before: () => {
+		sceditor.formats.bbcode.set(
+			'thisoldbbcode', {
+				tags: {
+					abbr: {
+						title: ['test'],
+						test: null
+					}
+				},
+				matchAttrs: 'all',
+				format: function (element, content) {
+					return '[abbr=' + element.getAttribute('title') + ']' + content + '[/abbr]';
+				},
+				html: '<abbr title="{defaultattr}">{0}</abbr>'
 			}
-		},
-		matchAttrs: 'all',
-		format: function (element, content) {
-			return '[abbr=' + element.getAttribute('title') + ']' + content + '[/abbr]';
-		},
-		html: '<abbr title="{defaultattr}">{0}</abbr>'
-	}
-);
-sceditor.formats.bbcode.set(
-	'springchicken', {
-		tags: {
-			bird: {
-				type: ['duck'],
-				test: null
+		);
+		sceditor.formats.bbcode.set(
+			'springchicken', {
+				tags: {
+					bird: {
+						type: ['duck'],
+						test: null
+					}
+				},
+				matchAttrs: 'any',
+				format: function (element, content) {
+					return '[bird=' + element.getAttribute('type') + ']' + content + '[/bird]';
+				},
+				html: '<bird type="{defaultattr}">{0}</bird>'
 			}
-		},
-		matchAttrs: 'any',
-		format: function (element, content) {
-			return '[bird=' + element.getAttribute('type') + ']' + content + '[/bird]';
-		},
-		html: '<bird type="{defaultattr}">{0}</bird>'
-	}
-);
-sceditor.formats.bbcode.set(
-	'insertnamehere', {
-		tags: {
-			species: {
-				classification: ['mammal'],
-				test: null
+		);
+		sceditor.formats.bbcode.set(
+			'insertnamehere', {
+				tags: {
+					species: {
+						classification: ['mammal'],
+						test: null
+					}
+				},
+				format: function (element, content) {
+					return '[species=' + element.getAttribute('classification') + ']' + content + '[/species]';
+				},
+				html: '<species classification="{defaultattr}">{0}</species>'
 			}
-		},
-		format: function (element, content) {
-			return '[species=' + element.getAttribute('classification') + ']' + content + '[/species]';
-		},
-		html: '<species classification="{defaultattr}">{0}</species>'
+		);
+		sceditor.formats.bbcode.set('margin', {
+			tags: {
+				'p': null
+			},
+			styles: {
+				'margin': null
+			},
+			format: function (element, content) {
+				return '[margin=' + element.style.margin + ']' +
+					content + '[/margin]';
+			},
+			html: '<p style="margin:{defaultattr}">{0}</p>'
+		});
+	},
+	beforeEach: function () {
+		this.mockEditor = {
+			opts: defaultOptions
+		};
+		this.format = new sceditor.formats.bbcode();
+		this.format.init.call(this.mockEditor);
+	},
+	after: () => {
+		sceditor.formats.bbcode.remove('thisoldbbcode');
+		sceditor.formats.bbcode.remove('springchicken');
+		sceditor.formats.bbcode.remove('insertnamehere');
+		sceditor.formats.bbcode.remove('margin');
 	}
-);
-sceditor.formats.bbcode.set('margin', {
-	tags: {
-		'p': null
-	},
-	styles: {
-		'margin': null
-	},
-	format: function (element, content) {
-		return '[margin=' + element.style.margin + ']' +
-			content + '[/margin]';
-	},
-	html: '<p style="margin:{defaultattr}">{0}</p>'
 });
-var
-	mockEditor = {
-		opts: defaultOptions
-	},
-	format = new sceditor.formats.bbcode;
-format.init.call(mockEditor);
 
-QUnit.test('match all attrs', assert => {
+QUnit.test('match all attrs', function (assert) {
 	assert.equal(
-		mockEditor.toBBCode(
+		this.mockEditor.toBBCode(
 			'<abbr title="attrs.defaultattr" test="value">content</abbr>'
 		),
 		'content'
 	);
 	assert.equal(
-		mockEditor.toBBCode('<abbr title="test" test="value">content</abbr>'),
+		this.mockEditor.toBBCode('<abbr title="test" test="value">content</abbr>'),
 		'[abbr=test]content[/abbr]'
 	);
 });
-QUnit.test('match any attr', assert => {
+QUnit.test('match any attr', function (assert) {
 	assert.equal(
-		mockEditor.toBBCode(
+		this.mockEditor.toBBCode(
 			'<bird type="attrs.defaultattr" test="value">content</bird>'
 		),
 		'[bird=attrs.defaultattr]content[/bird]'
 	);
 	assert.equal(
-		mockEditor.toBBCode('<bird type="duck" test="value">content</bird>'),
+		this.mockEditor.toBBCode('<bird type="duck" test="value">content</bird>'),
 		'[bird=duck]content[/bird]'
 	);
 });
-QUnit.test('match not specified', assert => {
+QUnit.test('match not specified', function (assert) {
 	assert.equal(
-		mockEditor.toBBCode(
+		this.mockEditor.toBBCode(
 			'<species classification="attrs.defaultattr" test="value">content</species>'
 		),
 		'[species=attrs.defaultattr]content[/species]'
 	);
 	assert.equal(
-		mockEditor.toBBCode('<species classification="mammal" test="value">content</species>'),
+		this.mockEditor.toBBCode('<species classification="mammal" test="value">content</species>'),
 		'[species=mammal]content[/species]'
 	);
 });
-QUnit.test('unexpected double match', assert => {
+QUnit.test('unexpected double match', function (assert) {
 	assert.equal(
-		mockEditor.toBBCode('<p style="margin: 1em;">content</p>'),
+		this.mockEditor.toBBCode('<p style="margin: 1em;">content</p>'),
 		'[margin=1em][margin=1em]content[/margin][/margin]'
 	);
 });
 
-// Remember to clean up!
-sceditor.formats.bbcode.remove('thisoldbbcode');
-sceditor.formats.bbcode.remove('springchicken');
-sceditor.formats.bbcode.remove('insertnamehere');
-sceditor.formats.bbcode.remove('margin');

--- a/tests/unit/formats/bbcode/nesting.js
+++ b/tests/unit/formats/bbcode/nesting.js
@@ -3,57 +3,56 @@ import 'src/formats/bbcode.js';
 
 QUnit.module('plugins/bbcode - Nesting');
 
-sceditor.formats.bbcode.set(
-	'thisblockstyle', {
-		styles: {
-			border: null
-		},
-		isInline: false,
-		format: '[block]{0}[/block]',
-		html: '<block>{0}</block>'
-	}
-);
-sceditor.formats.bbcode.set(
-	'thisinlinestyle', {
-		styles: {
-			opacity: null
-		},
-		format: '[inline]{0}[/inline]',
-		html: '<inline>{0}</inline>'
-	}
-);
-sceditor.formats.bbcode.set(
-	'thisblockbbcode', {
-		tags: {
-			block: {
-				test: null
-			}
-		},
-		isInline: false,
-		format: '[block]{0}[/block]',
-		html: '<block>{0}</block>'
-	}
-);
-sceditor.formats.bbcode.set(
-	'thisinlinebbcode', {
-		tags: {
-			block: {
-				testing: null
-			}
-		},
-		format: '[inline]{0}[/inline]',
-		html: '<inline>{0}</inline>'
-	}
-);
-
-var
-	mockEditor = {
-		opts: defaultOptions
-	},
-	format = new sceditor.formats.bbcode;
-format.init.call(mockEditor);
-
 QUnit.test('inline bbcodes must be inside block ones', assert => {
+	sceditor.formats.bbcode.set(
+		'thisblockstyle', {
+			styles: {
+				border: null
+			},
+			isInline: false,
+			format: '[block]{0}[/block]',
+			html: '<block>{0}</block>'
+		}
+	);
+	sceditor.formats.bbcode.set(
+		'thisinlinestyle', {
+			styles: {
+				opacity: null
+			},
+			format: '[inline]{0}[/inline]',
+			html: '<inline>{0}</inline>'
+		}
+	);
+	sceditor.formats.bbcode.set(
+		'thisblockbbcode', {
+			tags: {
+				block: {
+					test: null
+				}
+			},
+			isInline: false,
+			format: '[block]{0}[/block]',
+			html: '<block>{0}</block>'
+		}
+	);
+	sceditor.formats.bbcode.set(
+		'thisinlinebbcode', {
+			tags: {
+				block: {
+					testing: null
+				}
+			},
+			format: '[inline]{0}[/inline]',
+			html: '<inline>{0}</inline>'
+		}
+	);
+
+	var mockEditor = {
+		opts: defaultOptions
+	};
+	var format = new sceditor.formats.bbcode;
+	format.init.call(mockEditor);
+
 	assert.equal(
 		mockEditor.toBBCode('<theme style=opacity:1;border:none;"></theme>'),
 		'[block][inline][/inline][/block]'
@@ -62,9 +61,9 @@ QUnit.test('inline bbcodes must be inside block ones', assert => {
 		mockEditor.toBBCode('<block test="yhm" testing="lol"></block>'),
 		'[block][inline][/inline][/block]'
 	);
-});
 
-sceditor.formats.bbcode.remove('thisblockstyle');
-sceditor.formats.bbcode.remove('thisinlinestyle');
-sceditor.formats.bbcode.remove('thisblockbbcode');
-sceditor.formats.bbcode.remove('thisinlinebbcode');
+	sceditor.formats.bbcode.remove('thisblockstyle');
+	sceditor.formats.bbcode.remove('thisinlinestyle');
+	sceditor.formats.bbcode.remove('thisblockbbcode');
+	sceditor.formats.bbcode.remove('thisinlinebbcode');
+});


### PR DESCRIPTION
@live627  I've finally had a chance to update #821. This removes the MatchingMode enum and removes some global variables from the tests.

This also reverts some other code as currently, the `format` property of commands can be modified after the editor is created. It isn't great behaviour, and it is undocumented, but it is unfortunately used. As it doesn't need to change, it would be better not to break it until the next breaking release.

I've changed the settings back to allowing PRs to be merged without review (although it's probably a good idea to try to review them all as it is better practice), but please don't merge any PRs that have changes requested. I know it's annoying.

I've also enabled the Discussion tab (I thought it had been as it was there but it turns out that was a placeholder). I've added [some proposals](https://github.com/samclarke/SCEditor/discussions/849) for the next breaking change to modernise the codebase and make it a bit better.