### PR TITLE
Convert div tags inside tags in XHTML format.

### DIFF
--- a/src/formats/xhtml.js
+++ b/src/formats/xhtml.js
@@ -1198,6 +1198,18 @@
 
 				removeAttr(node, 'data-sce-target');
 			}
+		},
+		{
+			tags: {
+				code: null
+			},
+			conv: function (node) {
+				var node, nodes = node.getElementsByTagName('div');
+				while ((node = nodes[0])) {
+					node.style.display = 'block';
+					convertElement(node, 'span');
+				}
+			}
 		}
 	];
 

--- a/tests/unit/formats/xhtml.js
+++ b/tests/unit/formats/xhtml.js
@@ -980,3 +980,19 @@ QUnit.test('Should remove the nlf class from none empty nlf tags', function (ass
 	);
 });
 
+QUnit.test('Should convert divs inside code blocks to spans', function (assert) {
+	assert.htmlEqual(
+		this.filterStripWhiteSpace(
+			'<div><code>' +
+				'<div style="font-weight: bold">test</div>' +
+				'<div>test</div>' +
+			'</code></div>'
+		),
+		utils.stripWhiteSpace(
+			'<div><code>' +
+				'<span style="font-weight: bold; display: block;">test</span>' +
+				'<span style="display: block;">test</span>' +
+			'</code></div>'
+		)
+	);
+});


### PR DESCRIPTION
Converts all `<div>` tags that are in a `<code>` tag to `<span>` tags in the XHTML format.

`<div>` tags are invalid children of inline tags but are common when pasted. Currently `<code>` tags are split to fix this which isn't a good UX so this fixes that.