### PR TITLE
Initialize link dropdown description

### DIFF
--- a/src/formats/bbcode.js
+++ b/src/formats/bbcode.js
@@ -206,6 +206,7 @@
 				getEditorCommand('link')._dropDown(
 					editor,
 					caller,
+					selected,
 					function (url, text) {
 						editor.insertText(
 							'[url=' + url + ']' +

--- a/src/formats/xhtml.js
+++ b/src/formats/xhtml.js
@@ -164,6 +164,7 @@
 				getEditorCommand('link')._dropDown(
 					editor,
 					caller,
+					selected,
 					function (url, text) {
 						editor.insertText(
 							'<a href="' + url + '">' +

--- a/src/lib/defaultCommands.js
+++ b/src/lib/defaultCommands.js
@@ -563,13 +563,14 @@ var defaultCmds = {
 
 	// START_COMMAND: Link
 	link: {
-		_dropDown: function (editor, caller, cb) {
+		_dropDown: function (editor, caller, selected, cb) {
 			var content = dom.createElement('div');
 
 			dom.appendChild(content, _tmpl('link', {
 				url: editor._('URL:'),
 				desc: editor._('Description (optional):'),
-				ins: editor._('Insert')
+				ins: editor._('Insert'),
+				content: selected
 			}, true));
 
 			var linkInput = dom.find(content, '#link')[0];

--- a/src/lib/templates.js
+++ b/src/lib/templates.js
@@ -68,7 +68,7 @@ var _templates = {
 		'<div><label for="link">{url}</label> ' +
 			'<input type="text" id="link" dir="ltr" placeholder="https://" /></div>' +
 		'<div><label for="des">{desc}</label> ' +
-			'<input type="text" id="des" /></div>' +
+			'<input type="text" id="des" value="{content}"/></div>' +
 		'<div><input type="button" class="button" value="{ins}" /></div>',
 
 	youtubeMenu:


### PR DESCRIPTION
At present, when you select text and use the "link" command, a dropdown menu appears for the url itself and the description. However, the initial selected text is not propagated to the "description" box, which is confusing. Populate this box with any text that was selected before the url button was hit.