### PR TITLE
Reduce _normaliseColour regular expression range

### DIFF
--- a/src/formats/bbcode.js
+++ b/src/formats/bbcode.js
@@ -2188,6 +2188,7 @@
 
 		return number.length < 2 ? '0' + number : number;
 	}
+
 	/**
 	 * Normalises a CSS colour to hex #xxxxxx format
 	 *
@@ -2210,7 +2211,7 @@
 		}
 
 		// expand shorthand
-		if ((match = colorStr.match(/#([0-f])([0-f])([0-f])\s*?$/i))) {
+		if ((match = colorStr.match(/#([0-9a-f])([0-9a-f])([0-9a-f])\s*?$/i))) {
 			return '#' +
 				match[1] + match[1] +
 				match[2] + match[2] +

--- a/tests/unit/formats/bbcode.js
+++ b/tests/unit/formats/bbcode.js
@@ -541,20 +541,33 @@ QUnit.test('colour', function (assert) {
 	);
 
 	assert.equal(
-		this.htmlToBBCode('<font color="#000">test</font>'),
-		'[color=#000000]test[/color]',
+		this.htmlToBBCode('<font color="#0af">test</font>'),
+		'[color=#00aaff]test[/color]',
 		'Font tag color attribute short'
 	);
 
+
 	assert.equal(
-		this.htmlToBBCode('<font color="#000000">test</font>'),
-		'[color=#000000]test[/color]',
+		this.htmlToBBCode('<font color="#0AF">test</font>'),
+		'[color=#00AAFF]test[/color]',
+		'Font tag color attribute short uppercase'
+	);
+
+	assert.equal(
+		this.htmlToBBCode('<font color="#00aaff">test</font>'),
+		'[color=#00aaff]test[/color]',
 		'Font tag color attribute normal'
 	);
 
 	assert.equal(
-		this.htmlToBBCode('<font color="rgb(0,0,0)">test</font>'),
-		'[color=#000000]test[/color]',
+		this.htmlToBBCode('<font color="#0<>">test</font>'),
+		'[color=#0<>]test[/color]',
+		'Font tag color attribute non-hex characters'
+	);
+
+	assert.equal(
+		this.htmlToBBCode('<font color="rgb(0,170,255)">test</font>'),
+		'[color=#00aaff]test[/color]',
 		'Font tag color attribute rgb'
 	);
 });


### PR DESCRIPTION
This reduces the regular expression range in the _normaliseColour function. The regular expression should only match `0-9a-f` but it currently matches `0-f` which includes some extra characters.

This shouldn't matter too much as the function only attempts to normalise colours and returns the string as is if it can't but it should leave strings that don't match the `#xxx` format alone.