### PR TITLE
Update node action and remove cache action

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,20 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
       with:
-        node-version: 15
-    - name: Get npm cache directory
-      id: npm-cache-dir
-      run: echo "::set-output name=dir::$(npm root)"
-    - uses: actions/cache@v2
-      id: npm-cache
-      with:
-        path: ${{ steps.npm-cache-dir.outputs.dir }}
-        key: ${{ runner.os }}-node15-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: ${{ runner.os }}-node15-
+        node-version: 18
+        cache: 'npm'
     - run: npm -v
-    - if: steps.npm-cache.outputs.cache-hit != 'true'
-      run: npm ci
+    - run: npm ci
     - run: npm t


### PR DESCRIPTION
Updates the actions to the latest versions, updates node and removes the cache action as the setup-node action now has built in cache support.