### PR TITLE
Fix undo plugin error in Firefox when `selectedRange()` returns `null`

### DIFF
--- a/src/plugins/undo.js
+++ b/src/plugins/undo.js
@@ -39,9 +39,12 @@
 			} else {
 				editor.getBody().innerHTML = state.value;
 
-				var range = editor.getRangeHelper().selectedRange();
-				setRangePositions(range, state.caret);
-				editor.getRangeHelper().selectRange(range);
+				// Caret may not exist for the first state in Firefox
+				if (state.caret) {
+					var range = editor.getRangeHelper().selectedRange();
+					setRangePositions(range, state.caret);
+					editor.getRangeHelper().selectRange(range);
+				}
 			}
 
 			editor.focus();
@@ -282,6 +285,13 @@
 		 * @return {Object<string, Array<number>}
 		 */
 		function getRangePositions(range) {
+			// In Firefox, range may not exist when the editor is first created
+			// due to Firefox returning null from getSelection() when the
+			// editors iframe is first created. See issue #910
+			if (!range) {
+				return;
+			}
+
 			// Merge any adjacent text nodes as it will be done by innerHTML
 			// which would cause positions to be off if not done
 			body.normalize();


### PR DESCRIPTION
Firefox sometimes returns `null` from `getSelection()` when the editors `iframe` is first created. This fixes the issue by ignoring the range if it is `null`.

A better fix would be to only call the `ready` event on plugins when Firefox has created a selection object, however, I'm not sure there is a reliable way to do it.

Currently, the editor waits for the `load` event but there's no guarantee Firefox has created the selection object at that point. Other events like `DOMContentReady` fire earlier than `load` so are of no help. Timeouts could be used to repeatedly check if Firefox has created the selection and only call `ready` when the selection exists but that would be quite hacky and could lead to other subtle bugs which are hard to debug.

Fixes #910.