### PR TITLE
Fix unreliable autofocus in Firefox with manual test

### DIFF
--- a/tests/manual/debug/index.html
+++ b/tests/manual/debug/index.html
@@ -9,6 +9,7 @@
 		<script>
 			window.less = {
 				env: 'development',
+				async: true,
 				relativeUrls: true
 			};
 		</script>


### PR DESCRIPTION
This fixes an issue with auto focus being unreliable inside the manual test when using Firefox.

The issue is caused by Less.js hiding the editor until it has fully generated the CSS, this prevents Less.js from hiding the editor.

Fixes #912