### PR TITLE
Fix code tags including styles from block elements

### DIFF
--- a/src/formats/bbcode.js
+++ b/src/formats/bbcode.js
@@ -2437,7 +2437,7 @@
 		 * @memberOf SCEditor.plugins.bbcode.prototype
 		 */
 		function elementToBbcode(element) {
-			var toBBCode = function (node, vChildren) {
+			var toBBCode = function (node, vChildren, hasCodeParent) {
 				var ret = '';
 
 				dom.traverse(node, function (node) {
@@ -2478,20 +2478,23 @@
 
 						// don't convert iframe contents
 						if (tag !== 'iframe') {
-							content = toBBCode(node, vChild);
+							content = toBBCode(node, vChild,
+								hasCodeParent || tag === 'code');
 						}
 
 						// TODO: isValidChild is no longer needed. Should use
 						// valid children bbcodes instead by creating BBCode
 						// tokens like the parser.
 						if (isValidChild) {
-							// code tags should skip most styles
-							if (tag !== 'code') {
-								// First parse inline codes
-								content = handleTags(node, content, false);
-							}
+							if (!hasCodeParent) {
+								if (tag !== 'code') {
+									// Parse inline codes first so they don't
+									// contain block level codes
+									content = handleTags(node, content, false);
+								}
 
-							content = handleTags(node, content, true);
+								content = handleTags(node, content, true);
+							}
 							ret += handleBlockNewlines(node, content);
 						} else {
 							ret += content;

--- a/src/formats/bbcode.js
+++ b/src/formats/bbcode.js
@@ -2433,10 +2433,11 @@
 		 *
 		 * @private
 		 * @param {HTMLElement}	element
+		 * @param {boolean}	hasCodeParent
 		 * @return {string} BBCode
 		 * @memberOf SCEditor.plugins.bbcode.prototype
 		 */
-		function elementToBbcode(element) {
+		function elementToBbcode(element, hasCodeParent) {
 			var toBBCode = function (node, vChildren, hasCodeParent) {
 				var ret = '';
 
@@ -2507,7 +2508,7 @@
 				return ret;
 			};
 
-			return toBBCode(element);
+			return toBBCode(element, undefined, hasCodeParent);
 		};
 
 		/**
@@ -2561,6 +2562,7 @@
 			context = context || document;
 
 			var	bbcode, elements;
+			var hasCodeParent = !!dom.closest(parent, 'code');
 			var containerParent = context.createElement('div');
 			var container = context.createElement('div');
 			var parser = new BBCodeParser(base.opts.parserOptions);
@@ -2593,7 +2595,7 @@
 
 			dom.removeWhiteSpace(containerParent);
 
-			bbcode = elementToBbcode(container);
+			bbcode = elementToBbcode(container, hasCodeParent);
 
 			context.body.removeChild(containerParent);
 

--- a/tests/unit/formats/bbcode.js
+++ b/tests/unit/formats/bbcode.js
@@ -784,6 +784,47 @@ QUnit.test('Code', function (assert) {
 		'[code]ignore this Testing 1.2.3....[/code]\n',
 		'Code with styling'
 	);
+
+	assert.equal(
+		this.htmlToBBCode(
+			'<code><span style="color:#ff0000">test</span></code>'
+		),
+		'[code]test[/code]\n',
+		'Code with inline styling'
+	);
+
+	assert.equal(
+		this.htmlToBBCode(
+			'<code><div style="color:#ff0000">test</div></code>'
+		),
+		'[code]test[/code]\n',
+		'Code with block styling'
+	);
+
+
+	assert.equal(
+		this.htmlToBBCode(
+			'<code><div><div style="color:#ff0000">test</div></div></code>'
+		),
+		'[code]test[/code]\n',
+		'Code with nested block styling'
+	);
+
+	assert.equal(
+		this.htmlToBBCode(
+			'<code><div>line 1</div><div>line 2</div></code>'
+		),
+		'[code]line 1\nline 2[/code]\n',
+		'Code with block lines'
+	);
+
+	assert.equal(
+		this.htmlToBBCode(
+			'<code style="font-weight:bold">test</code>'
+		),
+		'[code]test[/code]\n',
+		'Code with styling'
+	);
 });
 
 

--- a/tests/unit/formats/bbcode.js
+++ b/tests/unit/formats/bbcode.js
@@ -825,6 +825,14 @@ QUnit.test('Code', function (assert) {
 		'[code]test[/code]\n',
 		'Code with styling'
 	);
+
+	assert.equal(
+		this.htmlToBBCode(
+			'<code><img data-sceditor-emoticon=":)" /></code>'
+		),
+		'[code]:)[/code]\n',
+		'Code with emoticon'
+	);
 });
 
 


### PR DESCRIPTION
Improves the special case handling for code tags so they only include text content. Also fixes BBCode formats paste handling to not convert styles if parent is a code tag.

Fixes #915