### PR TITLE
Add missing strings to translation template and German translation

### DIFF
--- a/languages/de.js
+++ b/languages/de.js
@@ -26,6 +26,8 @@
 		'Paste Text': 'Text einfügen',
 		'Bullet list': 'Aufzählungsliste',
 		'Numbered list': 'Nummerierte Liste',
+		'Add indent': 'Ebene hinzufügen',
+		'Remove one indent': 'Eine Ebene entfernen',
 		'Undo': 'Rückgängig machen',
 		'Redo': 'Wiederherstellen',
 		'Rows:': 'Zeilen',

--- a/languages/template.js
+++ b/languages/template.js
@@ -34,6 +34,8 @@
 		'Paste Text': '',
 		'Bullet list': '',
 		'Numbered list': '',
+		'Add indent': '',
+		'Remove one indent': '',
 		'Undo': '',
 		'Redo': '',
 		'Rows:': '',
@@ -57,6 +59,7 @@
 		'Insert current date': '',
 		'Insert current time': '',
 		'Print': '',
+		'Maximize': '',
 		'View source': '',
 		'Description (optional):': '',
 		'Enter the image URL:': '',
@@ -67,6 +70,8 @@
 		'Insert a Quote': '',
 		'Invalid YouTube video': '',
 		'Drop files here': '',
+		'Left-to-Right': '',
+		'Right-to-Left': '',
 
 		// month format, replace - with the date format separator and order in the
 		// order used


### PR DESCRIPTION
Adds some missing strings to the translation template and adds translations for the indent strings to German translation.

Fixes #918 