### PR TITLE
Update tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,7 +4,7 @@ const libCoverage = require('istanbul-lib-coverage');
 const libReport = require('istanbul-lib-report');
 const reports = require('istanbul-reports');
 const nodeResolve = require('@rollup/plugin-node-resolve').default;
-const rimraf = require('rimraf');
+const fs = require('fs');
 const path = require('path');
 
 module.exports = (grunt) => {
@@ -13,7 +13,7 @@ module.exports = (grunt) => {
 	grunt.event.on('qunit.coverage', function (data) {
 		const outputDir = __dirname + '/coverage';
 
-		rimraf.sync(outputDir);
+		fs.rmSync(outputDir, { recursive: true, force: true });
 
 		const coverageMap = libCoverage.createCoverageMap(data);
 		const context = libReport.createContext({

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
-        "dompurify": "^2.4.0"
+        "dompurify": "^2.4.3"
       },
       "devDependencies": {
         "@lodder/grunt-postcss": "^3.1.1",
         "@rollup/plugin-node-resolve": "^15.0.1",
         "autoprefixer": "^10.4.13",
         "cssnano": "^5.1.14",
-        "grunt": "~1.5.3",
+        "grunt": "~1.6.1",
         "grunt-contrib-clean": "^2.0.1",
         "grunt-contrib-compress": "^2.0.0",
         "grunt-contrib-concat": "~2.1.0",
@@ -24,21 +24,20 @@
         "grunt-contrib-less": "^3.0.0",
         "grunt-contrib-qunit": "^6.2.1",
         "grunt-contrib-uglify": "^5.2.2",
-        "grunt-eslint": "^24.0.0",
+        "grunt-eslint": "^24.0.1",
         "grunt-rollup": "^12.0.0",
         "istanbul-lib-coverage": "^3.2.0",
         "istanbul-lib-instrument": "^5.2.1",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-reports": "^3.1.5",
-        "jquery": "^3.6.1",
+        "jquery": "^3.6.3",
         "less": "^4.1.3",
-        "loader-utils": "^3.2.0",
-        "qunit": "^2.19.3",
+        "loader-utils": "^3.2.1",
+        "qunit": "^2.19.4",
         "rangy": "^1.3.1",
-        "rimraf": "^3.0.2",
-        "sinon": "^14.0.2",
+        "sinon": "^15.0.1",
         "time-grunt": "^2.0.0",
-        "webpack": "^5.74.0",
+        "webpack": "^5.75.0",
         "webpack-dev-server": "^4.11.1"
       },
       "engines": {
@@ -609,21 +608,12 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
-      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^1.7.0"
-      }
-    },
-    "node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.5.tgz",
-      "integrity": "sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "4.0.8"
+        "@sinonjs/commons": "^2.0.0"
       }
     },
     "node_modules/@sinonjs/samsam": {
@@ -2103,9 +2093,9 @@
       }
     },
     "node_modules/dateformat": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -2285,9 +2275,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.0.tgz",
-      "integrity": "sha512-Be9tbQMZds4a3C6xTmz68NlMfeONA//4dOavl/1rNw50E+/QO0KVpbcU0PcaW0nsQxurXls9ZocqFxk8R2mWEA=="
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.3.tgz",
+      "integrity": "sha512-q6QaLcakcRjebxjg8/+NP+h0rPfatOgOzc46Fst9VAA3jF2ApfKBNKMzdP4DYTqtUMXSCd5pRS/8Po/OmoCHZQ=="
     },
     "node_modules/domutils": {
       "version": "2.8.0",
@@ -3027,31 +3017,18 @@
       }
     },
     "node_modules/findup-sync": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
-      "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-5.0.0.tgz",
+      "integrity": "sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ==",
       "dev": true,
       "dependencies": {
-        "glob": "~5.0.0"
+        "detect-file": "^1.0.0",
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.4",
+        "resolve-dir": "^1.0.1"
       },
       "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/findup-sync/node_modules/glob": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-      "dev": true,
-      "dependencies": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
+        "node": ">= 10.13.0"
       }
     },
     "node_modules/fined": {
@@ -3090,6 +3067,21 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flat-cache/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/flatted": {
@@ -3375,32 +3367,30 @@
       "dev": true
     },
     "node_modules/grunt": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.5.3.tgz",
-      "integrity": "sha512-mKwmo4X2d8/4c/BmcOETHek675uOqw0RuA/zy12jaspWqvTp4+ZeQF1W+OTpcbncnaBsfbQJ6l0l4j+Sn/GmaQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.6.1.tgz",
+      "integrity": "sha512-/ABUy3gYWu5iBmrUSRBP97JLpQUm0GgVveDCp6t3yRNIoltIYw7rEj3g5y1o2PGPR2vfTRGa7WC/LZHLTXnEzA==",
       "dev": true,
       "dependencies": {
-        "dateformat": "~3.0.3",
+        "dateformat": "~4.6.2",
         "eventemitter2": "~0.4.13",
         "exit": "~0.1.2",
-        "findup-sync": "~0.3.0",
+        "findup-sync": "~5.0.0",
         "glob": "~7.1.6",
         "grunt-cli": "~1.4.3",
         "grunt-known-options": "~2.0.0",
         "grunt-legacy-log": "~3.0.0",
         "grunt-legacy-util": "~2.0.1",
-        "iconv-lite": "~0.4.13",
+        "iconv-lite": "~0.6.3",
         "js-yaml": "~3.14.0",
         "minimatch": "~3.0.4",
-        "mkdirp": "~1.0.4",
-        "nopt": "~3.0.6",
-        "rimraf": "~3.0.2"
+        "nopt": "~3.0.6"
       },
       "bin": {
         "grunt": "bin/grunt"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=16"
       }
     },
     "node_modules/grunt-cli": {
@@ -3615,9 +3605,9 @@
       }
     },
     "node_modules/grunt-eslint": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-24.0.0.tgz",
-      "integrity": "sha512-WpTeBBFweyhMuPjGwRSQV9JFJ+EczIdlsc7Dd/1g78QVI1aZsk4g/H3e+3S5HEwsS1RKL2YZIrGj8hMLlBfN8w==",
+      "version": "24.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-24.0.1.tgz",
+      "integrity": "sha512-gFzp+ikAkwyu6nqBE2zx1pLVL0JPrerG7jaO4uJV3XUGKPIipv4mfhDOS5MyiMrzUtGdXSW8FkRHjoUnfqbW+g==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2",
@@ -3701,6 +3691,18 @@
       },
       "peerDependencies": {
         "grunt": ">=0.4.0"
+      }
+    },
+    "node_modules/grunt/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/gzip-size": {
@@ -4381,9 +4383,9 @@
       }
     },
     "node_modules/jquery": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
-      "integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.3.tgz",
+      "integrity": "sha512-bZ5Sy3YzKo9Fyc8wH2iIQK4JImJ6R0GWI9kL1/k7Z91ZBNgkRXE6U0JfHIizZbort8ZunhSI3jw9I6253ahKfg==",
       "dev": true
     },
     "node_modules/js-tokens": {
@@ -4904,18 +4906,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -6166,6 +6156,21 @@
         "node": ">=10.18.1"
       }
     },
+    "node_modules/puppeteer/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/qs": {
       "version": "6.10.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
@@ -6182,9 +6187,9 @@
       }
     },
     "node_modules/qunit": {
-      "version": "2.19.3",
-      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.19.3.tgz",
-      "integrity": "sha512-vEnspSZ37u2oR01OA/IZ1Td5V7BvQYFECdKPv86JaBplDNa5IHg0v7jFSPoP5L5o78Dbi8sl7/ATtpRDAKlSdw==",
+      "version": "2.19.4",
+      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.19.4.tgz",
+      "integrity": "sha512-aqUzzUeCqlleWYKlpgfdHHw9C6KxkB9H3wNfiBg5yHqQMzy0xw/pbCRHYFkjl8MsP/t8qkTQE+JTYL71azgiew==",
       "dev": true,
       "dependencies": {
         "commander": "7.2.0",
@@ -6366,21 +6371,6 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rollup": {
@@ -6663,13 +6653,13 @@
       "dev": true
     },
     "node_modules/sinon": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.2.tgz",
-      "integrity": "sha512-PDpV0ZI3ZCS3pEqx0vpNp6kzPhHrLx72wA0G+ZLaaJjLIYeE0n8INlgaohKuGy7hP0as5tbUd23QWu5U233t+w==",
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.1.tgz",
+      "integrity": "sha512-PZXKc08f/wcA/BMRGBze2Wmw50CWPiAH3E21EOi4B49vJ616vW4DQh4fQrqsYox2aNR/N3kCqLuB0PwwOucQrg==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "^9.1.2",
+        "@sinonjs/fake-timers": "10.0.2",
         "@sinonjs/samsam": "^7.0.1",
         "diff": "^5.0.0",
         "nise": "^5.1.2",
@@ -7406,9 +7396,9 @@
       "dev": true
     },
     "node_modules/webpack": {
-      "version": "5.74.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+      "version": "5.75.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
+      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -7625,6 +7615,21 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
+    },
+    "node_modules/webpack-dev-server/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/webpack-dev-server/node_modules/schema-utils": {
       "version": "4.0.0",
@@ -8295,23 +8300,12 @@
       }
     },
     "@sinonjs/fake-timers": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
-      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.7.0"
-      },
-      "dependencies": {
-        "@sinonjs/commons": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.5.tgz",
-          "integrity": "sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==",
-          "dev": true,
-          "requires": {
-            "type-detect": "4.0.8"
-          }
-        }
+        "@sinonjs/commons": "^2.0.0"
       }
     },
     "@sinonjs/samsam": {
@@ -9493,9 +9487,9 @@
       }
     },
     "dateformat": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
       "dev": true
     },
     "debug": {
@@ -9621,9 +9615,9 @@
       }
     },
     "dompurify": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.0.tgz",
-      "integrity": "sha512-Be9tbQMZds4a3C6xTmz68NlMfeONA//4dOavl/1rNw50E+/QO0KVpbcU0PcaW0nsQxurXls9ZocqFxk8R2mWEA=="
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.3.tgz",
+      "integrity": "sha512-q6QaLcakcRjebxjg8/+NP+h0rPfatOgOzc46Fst9VAA3jF2ApfKBNKMzdP4DYTqtUMXSCd5pRS/8Po/OmoCHZQ=="
     },
     "domutils": {
       "version": "2.8.0",
@@ -10201,27 +10195,15 @@
       }
     },
     "findup-sync": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
-      "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-5.0.0.tgz",
+      "integrity": "sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ==",
       "dev": true,
       "requires": {
-        "glob": "~5.0.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
+        "detect-file": "^1.0.0",
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.4",
+        "resolve-dir": "^1.0.1"
       }
     },
     "fined": {
@@ -10251,6 +10233,17 @@
       "requires": {
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flatted": {
@@ -10459,26 +10452,35 @@
       "dev": true
     },
     "grunt": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.5.3.tgz",
-      "integrity": "sha512-mKwmo4X2d8/4c/BmcOETHek675uOqw0RuA/zy12jaspWqvTp4+ZeQF1W+OTpcbncnaBsfbQJ6l0l4j+Sn/GmaQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.6.1.tgz",
+      "integrity": "sha512-/ABUy3gYWu5iBmrUSRBP97JLpQUm0GgVveDCp6t3yRNIoltIYw7rEj3g5y1o2PGPR2vfTRGa7WC/LZHLTXnEzA==",
       "dev": true,
       "requires": {
-        "dateformat": "~3.0.3",
+        "dateformat": "~4.6.2",
         "eventemitter2": "~0.4.13",
         "exit": "~0.1.2",
-        "findup-sync": "~0.3.0",
+        "findup-sync": "~5.0.0",
         "glob": "~7.1.6",
         "grunt-cli": "~1.4.3",
         "grunt-known-options": "~2.0.0",
         "grunt-legacy-log": "~3.0.0",
         "grunt-legacy-util": "~2.0.1",
-        "iconv-lite": "~0.4.13",
+        "iconv-lite": "~0.6.3",
         "js-yaml": "~3.14.0",
         "minimatch": "~3.0.4",
-        "mkdirp": "~1.0.4",
-        "nopt": "~3.0.6",
-        "rimraf": "~3.0.2"
+        "nopt": "~3.0.6"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
       }
     },
     "grunt-cli": {
@@ -10647,9 +10649,9 @@
       }
     },
     "grunt-eslint": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-24.0.0.tgz",
-      "integrity": "sha512-WpTeBBFweyhMuPjGwRSQV9JFJ+EczIdlsc7Dd/1g78QVI1aZsk4g/H3e+3S5HEwsS1RKL2YZIrGj8hMLlBfN8w==",
+      "version": "24.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-24.0.1.tgz",
+      "integrity": "sha512-gFzp+ikAkwyu6nqBE2zx1pLVL0JPrerG7jaO4uJV3XUGKPIipv4mfhDOS5MyiMrzUtGdXSW8FkRHjoUnfqbW+g==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.2",
@@ -11209,9 +11211,9 @@
       }
     },
     "jquery": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
-      "integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.3.tgz",
+      "integrity": "sha512-bZ5Sy3YzKo9Fyc8wH2iIQK4JImJ6R0GWI9kL1/k7Z91ZBNgkRXE6U0JfHIizZbort8ZunhSI3jw9I6253ahKfg==",
       "dev": true
     },
     "js-tokens": {
@@ -11628,12 +11630,6 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
-    },
-    "mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true
     },
     "mkdirp-classic": {
       "version": "0.5.3",
@@ -12518,6 +12514,17 @@
         "tar-fs": "^2.0.0",
         "unbzip2-stream": "^1.3.3",
         "ws": "^7.2.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "qs": {
@@ -12530,9 +12537,9 @@
       }
     },
     "qunit": {
-      "version": "2.19.3",
-      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.19.3.tgz",
-      "integrity": "sha512-vEnspSZ37u2oR01OA/IZ1Td5V7BvQYFECdKPv86JaBplDNa5IHg0v7jFSPoP5L5o78Dbi8sl7/ATtpRDAKlSdw==",
+      "version": "2.19.4",
+      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.19.4.tgz",
+      "integrity": "sha512-aqUzzUeCqlleWYKlpgfdHHw9C6KxkB9H3wNfiBg5yHqQMzy0xw/pbCRHYFkjl8MsP/t8qkTQE+JTYL71azgiew==",
       "dev": true,
       "requires": {
         "commander": "7.2.0",
@@ -12669,15 +12676,6 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "dev": true
-    },
-    "rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.1.3"
-      }
     },
     "rollup": {
       "version": "2.78.1",
@@ -12916,13 +12914,13 @@
       "dev": true
     },
     "sinon": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.2.tgz",
-      "integrity": "sha512-PDpV0ZI3ZCS3pEqx0vpNp6kzPhHrLx72wA0G+ZLaaJjLIYeE0n8INlgaohKuGy7hP0as5tbUd23QWu5U233t+w==",
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.1.tgz",
+      "integrity": "sha512-PZXKc08f/wcA/BMRGBze2Wmw50CWPiAH3E21EOi4B49vJ616vW4DQh4fQrqsYox2aNR/N3kCqLuB0PwwOucQrg==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "^9.1.2",
+        "@sinonjs/fake-timers": "10.0.2",
         "@sinonjs/samsam": "^7.0.1",
         "diff": "^5.0.0",
         "nise": "^5.1.2",
@@ -13465,9 +13463,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.74.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+      "version": "5.75.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
+      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
@@ -13627,6 +13625,15 @@
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
           "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
         },
         "schema-utils": {
           "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@rollup/plugin-node-resolve": "^15.0.1",
     "autoprefixer": "^10.4.13",
     "cssnano": "^5.1.14",
-    "grunt": "~1.5.3",
+    "grunt": "~1.6.1",
     "grunt-contrib-clean": "^2.0.1",
     "grunt-contrib-compress": "^2.0.0",
     "grunt-contrib-concat": "~2.1.0",
@@ -61,24 +61,23 @@
     "grunt-contrib-less": "^3.0.0",
     "grunt-contrib-qunit": "^6.2.1",
     "grunt-contrib-uglify": "^5.2.2",
-    "grunt-eslint": "^24.0.0",
+    "grunt-eslint": "^24.0.1",
     "grunt-rollup": "^12.0.0",
     "istanbul-lib-coverage": "^3.2.0",
     "istanbul-lib-instrument": "^5.2.1",
     "istanbul-lib-report": "^3.0.0",
     "istanbul-reports": "^3.1.5",
-    "jquery": "^3.6.1",
+    "jquery": "^3.6.3",
     "less": "^4.1.3",
-    "loader-utils": "^3.2.0",
-    "qunit": "^2.19.3",
+    "loader-utils": "^3.2.1",
+    "qunit": "^2.19.4",
     "rangy": "^1.3.1",
-    "rimraf": "^3.0.2",
-    "sinon": "^14.0.2",
+    "sinon": "^15.0.1",
     "time-grunt": "^2.0.0",
-    "webpack": "^5.74.0",
+    "webpack": "^5.75.0",
     "webpack-dev-server": "^4.11.1"
   },
   "dependencies": {
-    "dompurify": "^2.4.0"
+    "dompurify": "^2.4.3"
   }
 }

--- a/tests/.eslintrc.json
+++ b/tests/.eslintrc.json
@@ -10,7 +10,8 @@
     "rangy": true,
     "sinon": true,
     "runner": true,
-    "patchConsole": true
+    "patchConsole": true,
+    "less": true
   },
   "rules": {
     "new-cap": "off",

--- a/tests/manual/debug/index.html
+++ b/tests/manual/debug/index.html
@@ -9,6 +9,7 @@
 		<script>
 			window.less = {
 				env: 'development',
+				async: true,
 				relativeUrls: true
 			};
 		</script>

--- a/tests/unit/htmlAssert.js
+++ b/tests/unit/htmlAssert.js
@@ -78,6 +78,21 @@ var compareHtml = function (actual, expected) {
 	return compareNodes(nodeA, nodeB);
 };
 
+function nodeToString(node) {
+	if (node.nodeType === Node.TEXT_NODE) {
+		return node.nodeValue;
+	}
+
+	if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
+		const template = document.createElement('template');
+		template.append(node.cloneNode(true));
+
+		return template.innerHTML;
+	}
+
+	return node.outerHTML;
+}
+
 QUnit.assert.htmlEqual = function (actual, expected, message) {
 	this.pushResult({
 		result: compareHtml(actual, expected),
@@ -102,8 +117,8 @@ QUnit.assert.nodesEqual = function (actual, expected, message) {
 
 	this.pushResult({
 		result: compareNodes(actual, expected),
-		actual: actual,
-		expected: expected,
+		actual: nodeToString(actual),
+		expected: nodeToString(expected),
 		message: message || 'Expected nodes to be equal'
 	});
 };
@@ -114,8 +129,8 @@ QUnit.assert.nodesNodeEqual = function (actual, expected, message) {
 
 	this.pushResult({
 		result: !compareNodes(actual, expected),
-		actual: actual,
-		expected: expected,
+		actual: nodeToString(actual),
+		expected: nodeToString(expected),
 		message: message || 'Expected nodes to not be equal'
 	});
 };

--- a/tests/unit/index.html
+++ b/tests/unit/index.html
@@ -8,6 +8,7 @@
 		<script>
 		var less = {
 			env: 'development',
+			async: true,
 			logLevel: 1,
 			relativeUrls: true
 		};

--- a/tests/unit/init.js
+++ b/tests/unit/init.js
@@ -2,6 +2,8 @@
 	// Report QUnit results to SauceLabs
 	var log = [];
 
+	QUnit.config.autostart = false;
+
 	QUnit.on('runEnd', function (testResults) {
 		var tests = [];
 
@@ -61,5 +63,9 @@
 				log.push(details);
 			}
 		};
+	});
+
+	less.pageLoadFinished.then(() => {
+		QUnit.start();
 	});
 }());

--- a/tests/unit/lib/SCEditor.js
+++ b/tests/unit/lib/SCEditor.js
@@ -5,12 +5,6 @@ import * as utils from 'tests/unit/utils.js';
 import rangy from 'rangy';
 
 
-// The selection based tests fail in phantom although they do work in
-// Chrome and Safari which are both based on Webkit. Should investigate
-// further but looks like phantomJS but rather than an editor but.
-// Might be an issue with phantomJS and iframes that have  selections.
-var IS_PHANTOMJS = navigator.userAgent.indexOf('PhantomJS') > -1;
-
 var $textarea;
 var sceditor;
 var $fixture = $('#qunit-module-fixture');
@@ -43,6 +37,7 @@ var reloadEditor = function (config) {
 		.append(textarea);
 
 	sceditor  = new SCEditor(textarea, config || {});
+	sceditor.focus();
 	$textarea = $(textarea);
 };
 
@@ -84,10 +79,6 @@ QUnit.module('lib/SCEditor', {
 });
 
 QUnit.test('autofocus', function (assert) {
-	if (IS_PHANTOMJS) {
-		return assert.expect(0);
-	}
-
 	reloadEditor({
 		autofocus: true,
 		autofocusEnd: false
@@ -168,10 +159,10 @@ QUnit.test('rtl()', function (assert) {
 QUnit.test('width()', function (assert) {
 	var $container = $fixture.children('.sceditor-container');
 
-	assert.equal(sceditor.width(), $container.width());
+	assert.close(sceditor.width(), $container.width(), 1);
 	assert.equal(sceditor.width('200'), sceditor);
 
-	assert.equal(sceditor.width(), $container.width());
+	assert.close(sceditor.width(), $container.width(), 1);
 	assert.close($container.width(), 200, 1);
 });
 
@@ -179,10 +170,10 @@ QUnit.test('width()', function (assert) {
 QUnit.test('height()', function (assert) {
 	var $container = $fixture.children('.sceditor-container');
 
-	assert.equal(sceditor.height(), $container.height());
+	assert.close(sceditor.height(), $container.height(), 1);
 	assert.equal(sceditor.height('200'), sceditor);
 
-	assert.equal(sceditor.height(), $container.height());
+	assert.close(sceditor.height(), $container.height(), 1);
 	assert.close($container.height(), 200, 1);
 });
 
@@ -245,10 +236,6 @@ QUnit.test('destroy() - Unbind updateOriginal', function (assert) {
 
 
 QUnit.test('wysiwygEditorInsertHtml()', function (assert) {
-	if (IS_PHANTOMJS) {
-		return assert.expect(0);
-	}
-
 	sceditor.focus();
 	var iframe = sceditor.getContentAreaContainer();
 	var body   = sceditor.getBody();
@@ -272,10 +259,6 @@ QUnit.test('wysiwygEditorInsertHtml()', function (assert) {
 });
 
 QUnit.test('wysiwygEditorInsertHtml() - Start and end', function (assert) {
-	if (IS_PHANTOMJS) {
-		return assert.expect(0);
-	}
-
 	sceditor.focus();
 	var iframe = sceditor.getContentAreaContainer();
 	var body   = sceditor.getBody();
@@ -300,10 +283,6 @@ QUnit.test('wysiwygEditorInsertHtml() - Start and end', function (assert) {
 
 
 QUnit.test('wysiwygEditorInsertText() - Start and end', function (assert) {
-	if (IS_PHANTOMJS) {
-		return assert.expect(0);
-	}
-
 	sceditor.focus();
 	var iframe = sceditor.getContentAreaContainer();
 	var body   = sceditor.getBody();
@@ -327,10 +306,6 @@ QUnit.test('wysiwygEditorInsertText() - Start and end', function (assert) {
 });
 
 QUnit.test('wysiwygEditorInsertText() - Start and end', function (assert) {
-	if (IS_PHANTOMJS) {
-		return assert.expect(0);
-	}
-
 	var iframe = sceditor.getContentAreaContainer();
 	var body   = sceditor.getBody();
 	var range  = rangy.createRange(body.ownerDocument);

--- a/tests/unit/lib/dom.js
+++ b/tests/unit/lib/dom.js
@@ -1,8 +1,6 @@
 import * as dom from 'src/lib/dom.js';
 import * as utils from 'tests/unit/utils.js';
 
-var IS_PHANTOMJS = navigator.userAgent.indexOf('PhantomJS') > -1;
-
 QUnit.module('lib/dom');
 
 QUnit.test('createElement() - Simple', function (assert) {
@@ -118,12 +116,6 @@ QUnit.test('on()', function (assert) {
 });
 
 QUnit.test('on() - Selector', function (assert) {
-	// PhantomJS sets the wrong event.target for dispatch event
-	if (IS_PHANTOMJS) {
-		assert.expect(0);
-		return;
-	}
-
 	var div = document.createElement('div');
 	var p = document.createElement('p');
 	var called = false;

--- a/tests/unit/plugins/autoyoutube.js
+++ b/tests/unit/plugins/autoyoutube.js
@@ -28,7 +28,7 @@ QUnit.test('Should convert YouTube URLs', function (assert) {
 
 	autoYoutube.signalPasteRaw.call(mockEditor, data);
 
-	assert.strictEqual(data.html, '<p>before ' +
+	assert.htmlEqual(data.html, '<p>before ' +
 		'<iframe width="560" height="315" frameborder="0" ' +
 		'src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ" ' +
 		'data-youtube-id="dQw4w9WgXcQ" allowfullscreen=""></iframe> ' +
@@ -60,7 +60,7 @@ QUnit.test('Should convert short YouTube URLs', function (assert) {
 
 	autoYoutube.signalPasteRaw.call(mockEditor, data);
 
-	assert.strictEqual(data.html, 'line 1<br>before ' +
+	assert.htmlEqual(data.html, 'line 1<br>before ' +
 		'<iframe width="560" height="315" frameborder="0" ' +
 		'src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ" ' +
 		'data-youtube-id="dQw4w9WgXcQ" allowfullscreen=""></iframe> ' +
@@ -120,7 +120,7 @@ QUnit.test('Should clear all styling if only contents is URL', function (assert)
 
 	autoYoutube.signalPasteRaw.call(mockEditor, data);
 
-	assert.strictEqual(data.html,
+	assert.htmlEqual(data.html,
 		'<iframe width="560" height="315" frameborder="0" ' +
 			'src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ" ' +
 			'data-youtube-id="dQw4w9WgXcQ" allowfullscreen=""></iframe>'
@@ -147,7 +147,7 @@ QUnit.test('Should clear styling if only child', function (assert) {
 
 	autoYoutube.signalPasteRaw.call(mockEditor, data);
 
-	assert.strictEqual(data.html,
+	assert.htmlEqual(data.html,
 		'tests<div>' +
 			'<iframe width="560" height="315" frameborder="0" ' +
 				'src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ" ' +
@@ -176,7 +176,7 @@ QUnit.test('Should not clear styling if has whitespace', function (assert) {
 
 	autoYoutube.signalPasteRaw.call(mockEditor, data);
 
-	assert.strictEqual(data.html,
+	assert.htmlEqual(data.html,
 		'tests<div class="some-style">' +
 			'<u>' +
 				'<b>' +


### PR DESCRIPTION
Some updates to the tests:

- Removes rimraf dependency and updates dependencies to latest versions
- Fix auto focus issue with manual test caused by Less.js, fixes #912.
- Waits for Less.js to load before running tests (prevent any issues like #912)
- Fixes autoYoutube tests in FF due to changed parameter ordering
- Updates the `nodesEqual()` and `nodesNotEqual()` assertions to give better diffs.