### PR TITLE
Fix merge() merging <br> tags

### DIFF
--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -1139,8 +1139,8 @@ export function merge(node) {
 		merge(node.childNodes[i]);
 	}
 
-	// Should only merge inline tags
-	if (!isInline(node)) {
+	// Should only merge inline tags and should not merge <br> tags
+	if (!isInline(node) || tagName === 'BR') {
 		return;
 	}
 

--- a/tests/unit/lib/dom.js
+++ b/tests/unit/lib/dom.js
@@ -1821,3 +1821,22 @@ QUnit.test('merge() - deep with siblings', function (assert) {
 		)
 	);
 });
+
+QUnit.test('merge() - <br> tags should not merge', function (assert) {
+	var node = utils.htmlToNode(
+		'<div>' +
+			'<br><br><br>' +
+		'</div>'
+	);
+
+	dom.merge(node);
+
+	assert.nodesEqual(
+		node,
+		utils.htmlToNode(
+			'<div>' +
+				'<br><br><br>' +
+			'</div>'
+		)
+	);
+});


### PR DESCRIPTION
Prevents the `merge()` function from merging consecutive `<br>`.