### PR TITLE
Fix checkWhitespace() error when no previous node

### DIFF
--- a/src/lib/emoticons.js
+++ b/src/lib/emoticons.js
@@ -32,7 +32,7 @@ export function checkWhitespace(node, rangeHelper) {
 		var range = rangeHelper.cloneSelected();
 		var rangeStart = -1;
 		var rangeStartContainer = range.startContainer;
-		var previousText = prev.nodeValue || '';
+		var previousText = (prev && prev.nodeValue) || '';
 
 		previousText += dom.data(emoticon, 'sceditor-emoticon');
 
@@ -62,8 +62,10 @@ export function checkWhitespace(node, rangeHelper) {
 		}
 
 		next.insertData(0, previousText);
-		dom.remove(prev);
 		dom.remove(emoticon);
+		if (prev) {
+			dom.remove(prev);
+		}
 
 		// Need to update the range starting position if it's been modified
 		if (rangeStart > -1) {

--- a/tests/unit/lib/emoticons.js
+++ b/tests/unit/lib/emoticons.js
@@ -254,6 +254,34 @@ QUnit.test('checkWhitespace() - Remove cursor placed after', function (assert) {
 	assert.ok(mockRangeHelper.selectRangeCalled);
 });
 
+QUnit.test('checkWhitespace() - Remove with no previous node', function (assert) {
+	var root = utils.htmlToDiv('<img data-sceditor-emoticon=":)" />test');
+
+	var mockRange = {
+		startContainer: root,
+		startOffset: 1,
+		setStart: function (container, offset) {
+			this.startContainer = container;
+			this.startOffset = offset;
+		},
+		collapse: function () {}
+	};
+
+	var mockRangeHelper = {
+		selectedRange: mockRange,
+		cloneSelected: function () {
+			return mockRange;
+		},
+		selectRange: function (range) {
+			this.selectedRange = range;
+		}
+	};
+
+	emoticons.checkWhitespace(root, mockRangeHelper);
+
+	assert.nodesEqual(root, utils.htmlToDiv(':)test'));
+});
+
 QUnit.test('checkWhitespace() - no emoticons', function (assert) {
 	assert.expect(0);
 


### PR DESCRIPTION
Fixes error with `checkWhitespace()` when using `emoticonsCompat` and an emoticon is matched to be removed but there is no previous node.

Fixes #933