### PR TITLE
Autofocus on pageshow

### DIFF
--- a/src/lib/SCEditor.js
+++ b/src/lib/SCEditor.js
@@ -490,10 +490,6 @@ export default function SCEditor(original, userOptions) {
 		var loaded = function () {
 			dom.off(globalWin, 'load', loaded);
 
-			if (options.autofocus) {
-				autofocus(!!options.autofocusEnd);
-			}
-
 			autoExpand();
 			appendNewLine();
 			// TODO: use editor doc and window?
@@ -2589,8 +2585,12 @@ export default function SCEditor(original, userOptions) {
 	 * Handles form reset event
 	 * @private
 	 */
-	handleFormReset = function () {
+	handleFormReset = function (e) {
 		base.val(original.value);
+
+		if (e.type === 'pageshow' && options.autofocus) {
+			autofocus(!!options.autofocusEnd);
+		}
 	};
 
 	/**


### PR DESCRIPTION
This one proved difficult to track down, mainly because I thought the autofocus code was broken. After trying to fix it, I trike  `MutationObserver`. That showed the DOM written twice. This does not fix that, since I could ever see the `persisted` value as `true`.

All in all, too many hours spent in debugging hell.